### PR TITLE
Add support for the new IPv4Pools and IPv6Pools properties on AutoAssign

### DIFF
--- a/calico_cni_ipam_test.go
+++ b/calico_cni_ipam_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Calico IPAM Tests", func() {
 			DescribeTable("Request different numbers of IP addresses",
 				func(expectedIPv4, expectedIPv6 bool, netconf string) {
 
-					result, _ := RunIPAMPlugin(netconf, "ADD", "")
+					result, _, _ := RunIPAMPlugin(netconf, "ADD", "")
 
 					if expectedIPv4 {
 						Expect(result.IP4.IP.Mask.String()).Should(Equal("ffffffff"))
@@ -36,7 +36,7 @@ var _ = Describe("Calico IPAM Tests", func() {
 					}
 
 					// I can't find any testable side effects for this
-					_, _ = RunIPAMPlugin(netconf, "DEL", "")
+					_, _, _ = RunIPAMPlugin(netconf, "DEL", "")
 				},
 				Entry("IPAM with no configuration", true, false, fmt.Sprintf(`
 			{
@@ -85,80 +85,75 @@ var _ = Describe("Calico IPAM Tests", func() {
 
 	Describe("Run IPAM plugin - Verify IP Pools", func() {
 		Context("Pass valid pools", func() {
-			It("successfully networks the namespace", func() {
+			It("Uses the ipv4 pool", func() {
 				netconf := fmt.Sprintf(`
-			        {
-			          "name": "net1",
-			          "type": "calico",
-			          "etcd_endpoints": "http://%s:2379",
-			          "ipam": {
-			            "type": "%s",
-			            "assign_ipv4": "true",
-						"ipv4_pools": [ "192.168.0.0/16" ]
-			          }
-			        }`, os.Getenv("ETCD_IP"), plugin)
-				_, _, _, _, _, _, err := CreateContainer(netconf)
-				Expect(err).ShouldNot(HaveOccurred())
+                {
+                      "name": "net1",
+                      "type": "calico",
+                      "etcd_endpoints": "http://%s:2379",
+                      "ipam": {
+                        "type": "%s",
+                        "assign_ipv4": "true",
+                        "ipv4_pools": [ "192.168.0.0/16" ]
+                      }
+                }`, os.Getenv("ETCD_IP"), plugin)
+				result, _, _ := RunIPAMPlugin(netconf, "ADD", "")
+				Expect(result.IP4.IP.String()).Should(HavePrefix("192.168."))
 			})
 		})
 
 		Context("Pass more than one pool", func() {
-			It("successfully networks the namespace", func() {
-				PreCreatePool("192.169.1.0/24")
+			It("Uses one of the ipv4 pools", func() {
+				testutils.CreateNewIPPool(*calicoClient, "192.169.1.0/24", false, false, true)
 				netconf := fmt.Sprintf(`
-			        {
-			          "name": "net1",
-			          "type": "calico",
-			          "etcd_endpoints": "http://%s:2379",
-			          "ipam": {
-			            "type": "%s",
-			            "assign_ipv4": "true",
-						"ipv4_pools": [ "192.169.1.0/24", "192.168.0.0/16" ]
-			          }
-			        }`, os.Getenv("ETCD_IP"), plugin)
-				_, _, session, _, _, _, err := CreateContainer(netconf)
-				if err != nil {
-					fmt.Printf("Session Err: %v\n", string(session.Err.Contents()))
-				}
-				Expect(err).ShouldNot(HaveOccurred())
+                {
+                      "name": "net1",
+                      "type": "calico",
+                      "etcd_endpoints": "http://%s:2379",
+                      "ipam": {
+                        "type": "%s",
+                        "assign_ipv4": "true",
+                        "ipv4_pools": [ "192.169.1.0/24", "192.168.0.0/16" ]
+                      }
+                }`, os.Getenv("ETCD_IP"), plugin)
+				result, _, _ := RunIPAMPlugin(netconf, "ADD", "")
+				Expect(result.IP4.IP.String()).Should(Or(HavePrefix("192.168."), HavePrefix("192.169.1")))
 			})
 		})
 
 		Context("Pass an invalid pool", func() {
-			It("fails to network the namespace", func() {
+			It("fails to get an IP", func() {
 				// Put the bogus pool last in the array
 				netconf := fmt.Sprintf(`
-			        {
-			          "name": "net1",
-			          "type": "calico",
-			          "etcd_endpoints": "http://%s:2379",
-			          "ipam": {
-			            "type": "%s",
-			            "assign_ipv4": "true",
-						"ipv4_pools": [ "192.168.0.0/16", "192.169.1.0/24" ]
-			          }
-			        }`, os.Getenv("ETCD_IP"), plugin)
-				_, _, session, _, _, _, err := CreateContainer(netconf)
-				Expect(err).Should(HaveOccurred())
-				Expect(session.Err.Contents()).Should(ContainSubstring("192.169.1.0/24) does not exist"))
+                    {
+                      "name": "net1",
+                      "type": "calico",
+                      "etcd_endpoints": "http://%s:2379",
+                      "ipam": {
+                        "type": "%s",
+                        "assign_ipv4": "true",
+                        "ipv4_pools": [ "192.168.0.0/16", "192.169.1.0/24" ]
+                      }
+                    }`, os.Getenv("ETCD_IP"), plugin)
+				_, error, _ := RunIPAMPlugin(netconf, "ADD", "")
+				Expect(error.Msg).Should(ContainSubstring("192.169.1.0/24) does not exist"))
 			})
 
-			It("fails to network the namespace", func() {
+			It("fails to get an IP", func() {
 				// Put the bogus pool first in the array
 				netconf := fmt.Sprintf(`
-			        {
-			          "name": "net1",
-			          "type": "calico",
-			          "etcd_endpoints": "http://%s:2379",
-			          "ipam": {
-			            "type": "%s",
-			            "assign_ipv4": "true",
-						"ipv4_pools": [ "192.169.1.0/24", "192.168.0.0/16" ]
-			          }
-			        }`, os.Getenv("ETCD_IP"), plugin)
-				_, _, session, _, _, _, err := CreateContainer(netconf)
-				Expect(err).Should(HaveOccurred())
-				Expect(session.Err.Contents()).Should(ContainSubstring("192.169.1.0/24) does not exist"))
+                    {
+                      "name": "net1",
+                      "type": "calico",
+                      "etcd_endpoints": "http://%s:2379",
+                      "ipam": {
+                        "type": "%s",
+                        "assign_ipv4": "true",
+                        "ipv4_pools": [ "192.168.0.0/16", "192.169.1.0/24" ]
+                      }
+                    }`, os.Getenv("ETCD_IP"), plugin)
+				_, error, _ := RunIPAMPlugin(netconf, "ADD", "")
+				Expect(error.Msg).Should(ContainSubstring("192.169.1.0/24) does not exist"))
 			})
 		})
 
@@ -175,20 +170,20 @@ var _ = Describe("Calico IPAM Tests", func() {
 					}`, os.Getenv("ETCD_IP"), plugin)
 		Context("Pass explicit IP address", func() {
 			It("Return the expected IP", func() {
-				result, _ := RunIPAMPlugin(netconf, "ADD", "IP=192.168.123.123")
+				result, _, _ := RunIPAMPlugin(netconf, "ADD", "IP=192.168.123.123")
 				Expect(result.IP4.IP.String()).Should(Equal("192.168.123.123/32"))
 			})
 			It("Return the expected IP twice after deleting in the middle", func() {
-				result, _ := RunIPAMPlugin(netconf, "ADD", "IP=192.168.123.123")
+				result, _, _ := RunIPAMPlugin(netconf, "ADD", "IP=192.168.123.123")
 				Expect(result.IP4.IP.String()).Should(Equal("192.168.123.123/32"))
-				_, _ = RunIPAMPlugin(netconf, "DEL", "IP=192.168.123.123")
-				result, _ = RunIPAMPlugin(netconf, "ADD", "IP=192.168.123.123")
+				_, _, _ = RunIPAMPlugin(netconf, "DEL", "IP=192.168.123.123")
+				result, _, _ = RunIPAMPlugin(netconf, "ADD", "IP=192.168.123.123")
 				Expect(result.IP4.IP.String()).Should(Equal("192.168.123.123/32"))
 			})
 			It("Doesn't allow an explicit IP to be assigned twice", func() {
-				result, _ := RunIPAMPlugin(netconf, "ADD", "IP=192.168.123.123")
+				result, _, _ := RunIPAMPlugin(netconf, "ADD", "IP=192.168.123.123")
 				Expect(result.IP4.IP.String()).Should(Equal("192.168.123.123/32"))
-				result, exitCode := RunIPAMPlugin(netconf, "ADD", "IP=192.168.123.123")
+				result, _, exitCode := RunIPAMPlugin(netconf, "ADD", "IP=192.168.123.123")
 				Expect(exitCode).Should(BeNumerically(">", 0))
 			})
 		})

--- a/calico_cni_k8s_test.go
+++ b/calico_cni_k8s_test.go
@@ -53,11 +53,10 @@ var _ = Describe("CalicoCni", func() {
 			    "subnet": "10.0.0.0/8"
 			  },
 				"kubernetes": {
-					        "k8s_api_root": "http://127.0.0.1:8080"
-									    
+                  "k8s_api_root": "http://127.0.0.1:8080"
 				},
 				"policy": {"type": "k8s"},
-	"log_level":"info"
+				"log_level":"info"
 			}`, os.Getenv("ETCD_IP"))
 
 			It("successfully networks the namespace", func() {
@@ -70,8 +69,11 @@ var _ = Describe("CalicoCni", func() {
 				if err != nil {
 					panic(err)
 				}
+
 				name := fmt.Sprintf("run%d", rand.Uint32())
 				interfaceName := k8s.VethNameForWorkload(fmt.Sprintf("%s.%s", K8S_TEST_NS, name))
+
+				// Create a K8s pod w/o any special params
 				_, err = clientset.Pods(K8S_TEST_NS).Create(&v1.Pod{
 					ObjectMeta: v1.ObjectMeta{Name: name},
 					Spec: v1.PodSpec{Containers: []v1.Container{{
@@ -82,6 +84,26 @@ var _ = Describe("CalicoCni", func() {
 				if err != nil {
 					panic(err)
 				}
+
+				// Now create a K8s pod passing in an IP pool
+				name2 := name + "-pool"
+				pod, err := clientset.Pods(K8S_TEST_NS).Create(&v1.Pod{
+					ObjectMeta: v1.ObjectMeta{
+						Name: name2,
+						Annotations: map[string]string{
+							"cni.calico/ipv4pools": "192.169.1.0/24",
+						},
+					},
+					Spec: v1.PodSpec{Containers: []v1.Container{{
+						Name:  fmt.Sprintf("container-%s", name2),
+						Image: "ignore",
+					}}},
+				})
+				if err != nil {
+					panic(err)
+				}
+				fmt.Printf("POD: %#v\n", pod)
+
 				containerID, netnspath, session, contVeth, contAddresses, contRoutes, err := CreateContainer(netconf, name)
 				Expect(err).ShouldNot(HaveOccurred())
 				Eventually(session).Should(gexec.Exit())

--- a/calico_cni_k8s_test.go
+++ b/calico_cni_k8s_test.go
@@ -53,7 +53,7 @@ var _ = Describe("CalicoCni", func() {
 			    "subnet": "10.0.0.0/8"
 			  },
 				"kubernetes": {
-                  "k8s_api_root": "http://127.0.0.1:8080"
+				  "k8s_api_root": "http://127.0.0.1:8080"
 				},
 				"policy": {"type": "k8s"},
 				"log_level":"info"
@@ -84,27 +84,8 @@ var _ = Describe("CalicoCni", func() {
 				if err != nil {
 					panic(err)
 				}
-
-				// Now create a K8s pod passing in an IP pool
-				name2 := name + "-pool"
-				pod, err := clientset.Pods(K8S_TEST_NS).Create(&v1.Pod{
-					ObjectMeta: v1.ObjectMeta{
-						Name: name2,
-						Annotations: map[string]string{
-							"cni.calico/ipv4pools": "192.169.1.0/24",
-						},
-					},
-					Spec: v1.PodSpec{Containers: []v1.Container{{
-						Name:  fmt.Sprintf("container-%s", name2),
-						Image: "ignore",
-					}}},
-				})
-				if err != nil {
-					panic(err)
-				}
-				fmt.Printf("POD: %#v\n", pod)
-
 				containerID, netnspath, session, contVeth, contAddresses, contRoutes, err := CreateContainer(netconf, name)
+
 				Expect(err).ShouldNot(HaveOccurred())
 				Eventually(session).Should(gexec.Exit())
 
@@ -190,6 +171,44 @@ var _ = Describe("CalicoCni", func() {
 				Expect(err).Should(HaveOccurred())
 				Expect(err.Error()).Should(Equal("Link not found"))
 
+				// Now create a K8s pod passing in an IP pool
+				name2 := name + "-pool"
+				pod, err := clientset.Pods(K8S_TEST_NS).Create(&v1.Pod{
+					ObjectMeta: v1.ObjectMeta{
+						Name: name2,
+						Annotations: map[string]string{
+							"ipam.cni.projectcalico.org/ipv4pools": "192.169.1.0/24",
+						},
+					},
+					Spec: v1.PodSpec{Containers: []v1.Container{{
+						Name:  fmt.Sprintf("container-%s", name2),
+						Image: "ignore",
+					}}},
+				})
+				if err != nil {
+					panic(err)
+				}
+
+				fmt.Printf("POD: %#v\n", pod)
+
+				/*
+					// Wait for the pod to be created
+					for {
+						pod, err = clientset.Pods(K8S_TEST_NS).Get(name2)
+						fmt.Printf("POD2: %#v\n", pod)
+						if pod.Status.Phase != "Pending" {
+							break
+						}
+						time.Sleep(5 * time.Second)
+					}
+					fmt.Printf("POD2: %#v\n", pod)
+				*/
+
+				containerID, netnspath, session, contVeth, contAddresses, contRoutes, err = CreateContainer(netconf, name2)
+
+				// This will fail until I figure out how to call the CNI plugin
+				ip = contAddresses[0].IP.String()
+				Expect(ip).Should(Equal("192.169.1.0"))
 			})
 		})
 	})

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 1efa10f7d9f9793128d78496760c641fb6ee82b2686a4fd476ba83a624f1506c
-updated: 2017-01-02T13:52:34.929573726Z
+updated: 2016-12-13T15:51:57.719804486-08:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -20,7 +20,7 @@ imports:
   - pkg/utils/hwaddr
   - pkg/version
 - name: github.com/coreos/etcd
-  version: 24601ca24b46f5d700746c5902ee62aca6b1b805
+  version: 454f1da2f2bc48f9d2aede84fece95d292c8e3fc
   subpackages:
   - client
   - pkg/fileutil
@@ -165,7 +165,6 @@ imports:
   - lib/net
   - lib/numorstring
   - lib/scope
-  - lib/testutils
 - name: github.com/PuerkitoBio/purell
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc
@@ -173,7 +172,7 @@ imports:
 - name: github.com/satori/go.uuid
   version: b061729afc07e77a8aa4fad0a2fd840958f1942a
 - name: github.com/Sirupsen/logrus
-  version: 881bee4e20a5d11a6a88a5667c6f292072ac1963
+  version: d26492970760ca5d33129d2d799e34be5c4782eb
 - name: github.com/spf13/pflag
   version: c7e63cf4530bcd3ba943729cee0efeff2ebea63f
 - name: github.com/ugorji/go
@@ -207,7 +206,7 @@ imports:
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: d75a52659825e75fff6158388dddc6a5b04f9ba5
+  version: 478fcf54317e52ab69f40bb4c7a1520288d7f7ea
   subpackages:
   - unix
 - name: golang.org/x/text

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 1efa10f7d9f9793128d78496760c641fb6ee82b2686a4fd476ba83a624f1506c
-updated: 2016-12-13T15:51:57.719804486-08:00
+updated: 2017-01-02T13:52:34.929573726Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -20,7 +20,7 @@ imports:
   - pkg/utils/hwaddr
   - pkg/version
 - name: github.com/coreos/etcd
-  version: 454f1da2f2bc48f9d2aede84fece95d292c8e3fc
+  version: 24601ca24b46f5d700746c5902ee62aca6b1b805
   subpackages:
   - client
   - pkg/fileutil
@@ -165,6 +165,7 @@ imports:
   - lib/net
   - lib/numorstring
   - lib/scope
+  - lib/testutils
 - name: github.com/PuerkitoBio/purell
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc
@@ -172,7 +173,7 @@ imports:
 - name: github.com/satori/go.uuid
   version: b061729afc07e77a8aa4fad0a2fd840958f1942a
 - name: github.com/Sirupsen/logrus
-  version: d26492970760ca5d33129d2d799e34be5c4782eb
+  version: 881bee4e20a5d11a6a88a5667c6f292072ac1963
 - name: github.com/spf13/pflag
   version: c7e63cf4530bcd3ba943729cee0efeff2ebea63f
 - name: github.com/ugorji/go
@@ -206,7 +207,7 @@ imports:
   - jws
   - jwt
 - name: golang.org/x/sys
-  version: 478fcf54317e52ab69f40bb4c7a1520288d7f7ea
+  version: d75a52659825e75fff6158388dddc6a5b04f9ba5
   subpackages:
   - unix
 - name: golang.org/x/text

--- a/ipam/calico-ipam.go
+++ b/ipam/calico-ipam.go
@@ -114,7 +114,24 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 		fmt.Fprintf(os.Stderr, "Calico CNI IPAM request count IPv4=%d IPv6=%d\n", num4, num6)
 
-		assignArgs := client.AutoAssignArgs{Num4: num4, Num6: num6, HandleID: &workloadID, Hostname: conf.Hostname}
+		v4pools, err := utils.ParsePools(conf.IPAM.IPv4Pools, true)
+		if err != nil {
+			return err
+		}
+
+		v6pools, err := utils.ParsePools(conf.IPAM.IPv6Pools, false)
+		if err != nil {
+			return err
+		}
+
+		assignArgs := client.AutoAssignArgs{
+			Num4:      num4,
+			Num6:      num6,
+			HandleID:  &workloadID,
+			Hostname:  conf.Hostname,
+			IPv4Pools: v4pools,
+			IPv6Pools: v6pools,
+		}
 		logger.WithField("assignArgs", assignArgs).Info("Auto assigning IP")
 		assignedV4, assignedV6, err := calicoClient.IPAM().AutoAssign(assignArgs)
 		fmt.Fprintf(os.Stderr, "Calico CNI IPAM assigned addresses IPv4=%v IPv6=%v\n", assignedV4, assignedV6)

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -103,6 +103,54 @@ func CmdAddK8s(args *skel.CmdArgs, conf utils.NetConf, hostname string, calicoCl
 			logger.WithField("stdin", args.StdinData).Debug("Updated stdin data")
 		}
 
+		// Only used by K8s so if its null then we're not doing k8s stuff
+		var labels map[string]string
+		var annot map[string]string
+
+		// Only attempt to fetch the labels and annotations from Kubernetes
+		// if the policy type has been set to "k8s". This allows users to
+		// run the plugin under Kubernetes without needing it to access the
+		// Kubernetes API
+		if conf.Policy.PolicyType == "k8s" {
+			var err error
+
+			labels, annot, err = getK8sLabelsAnnotations(client, k8sArgs)
+			if err != nil {
+				// Cleanup IP allocation and return the error.
+				utils.ReleaseIPAllocation(logger, conf.IPAM.Type, args.StdinData)
+				return nil, err
+			}
+			logger.WithField("labels", labels).Debug("Fetched K8s labels")
+			logger.WithField("annotations", annot).Debug("Fetched K8s annotations")
+
+			v4pools := annot["cni.calico/ipv4pools"]
+			v6pools := annot["cni.calico/ipv6pools"]
+
+			if len(v4pools) != 0 || len(v6pools) != 0 {
+				var stdinData map[string]interface{}
+				if err := json.Unmarshal(args.StdinData, &stdinData); err != nil {
+					utils.ReleaseIPAllocation(logger, conf.IPAM.Type, args.StdinData)
+					return nil, err
+				}
+				stdinData["ipam"].(map[string]interface{})["ipv4pools"] = v4pools
+				stdinData["ipam"].(map[string]interface{})["ipv6pools"] = v6pools
+
+				if len(v4pools) > 0 {
+					fmt.Fprintf(os.Stderr, "Calico CNI setting ipv4pools to %q", v4pools)
+				}
+				if len(v6pools) > 0 {
+					fmt.Fprintf(os.Stderr, "Calico CNI setting ipv6pools to %q", v6pools)
+				}
+				newData, err := json.Marshal(stdinData)
+				if err != nil {
+					utils.ReleaseIPAllocation(logger, conf.IPAM.Type, args.StdinData)
+					return nil, err
+				}
+				args.StdinData = newData
+				logger.WithField("stdin", args.StdinData).Debug("Updated stdin data")
+			}
+		}
+
 		// Run the IPAM plugin
 		logger.Debugf("Calling IPAM plugin %s", conf.IPAM.Type)
 		result, err = ipam.ExecAdd(conf.IPAM.Type, args.StdinData)
@@ -117,7 +165,7 @@ func CmdAddK8s(args *skel.CmdArgs, conf utils.NetConf, hostname string, calicoCl
 		endpoint.Metadata.Node = hostname
 		endpoint.Metadata.Orchestrator = orchestrator
 		endpoint.Metadata.Workload = workload
-		endpoint.Metadata.Labels = make(map[string]string)
+		endpoint.Metadata.Labels = labels // Only when policy type == k8s
 
 		// Set the profileID according to whether Kubernetes policy is required.
 		// If it's not, then just use the network name (which is the normal behavior)
@@ -135,19 +183,6 @@ func CmdAddK8s(args *skel.CmdArgs, conf utils.NetConf, hostname string, calicoCl
 			return nil, err
 		}
 		logger.WithField("endpoint", endpoint).Info("Populated endpoint")
-
-		// Only attempt to fetch the labels from Kubernetes if the policy type has been set to "k8s"
-		// This allows users to run the plugin under Kubernetes without needing it to access the Kubernetes API
-		if conf.Policy.PolicyType == "k8s" {
-			labels, err := getK8sLabels(client, k8sArgs)
-			if err != nil {
-				// Cleanup IP allocation and return the error.
-				utils.ReleaseIPAllocation(logger, conf.IPAM.Type, args.StdinData)
-				return nil, err
-			}
-			logger.WithField("labels", labels).Info("Fetched K8s labels")
-			endpoint.Metadata.Labels = labels
-		}
 	}
 	fmt.Fprintf(os.Stderr, "Calico CNI using IPs: %s\n", endpoint.Spec.IPNetworks)
 
@@ -232,20 +267,20 @@ func newK8sClient(conf utils.NetConf, logger *log.Entry) (*kubernetes.Clientset,
 	return kubernetes.NewForConfig(config)
 }
 
-func getK8sLabels(client *kubernetes.Clientset, k8sargs utils.K8sArgs) (map[string]string, error) {
-	pods, err := client.Pods(string(k8sargs.K8S_POD_NAMESPACE)).Get(fmt.Sprintf("%s", k8sargs.K8S_POD_NAME))
+func getK8sLabelsAnnotations(client *kubernetes.Clientset, k8sargs utils.K8sArgs) (map[string]string, map[string]string, error) {
+	pod, err := client.Pods(string(k8sargs.K8S_POD_NAMESPACE)).Get(fmt.Sprintf("%s", k8sargs.K8S_POD_NAME))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	labels := pods.Labels
+	labels := pod.Labels
 	if labels == nil {
 		labels = make(map[string]string)
 	}
 
 	labels["calico/k8s_ns"] = fmt.Sprintf("%s", k8sargs.K8S_POD_NAMESPACE)
 
-	return labels, nil
+	return labels, pod.Annotations, nil
 }
 
 func getPodCidr(client *kubernetes.Clientset, conf utils.NetConf, hostname string) (string, error) {

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -123,8 +123,8 @@ func CmdAddK8s(args *skel.CmdArgs, conf utils.NetConf, hostname string, calicoCl
 			logger.WithField("labels", labels).Debug("Fetched K8s labels")
 			logger.WithField("annotations", annot).Debug("Fetched K8s annotations")
 
-			v4pools := annot["cni.calico/ipv4pools"]
-			v6pools := annot["cni.calico/ipv6pools"]
+			v4pools := annot["ipam.cni.projectcalico.org/ipv4pools"]
+			v6pools := annot["ipam.cni.projectcalico.org/ipv6pools"]
 
 			if len(v4pools) != 0 || len(v6pools) != 0 {
 				var stdinData map[string]interface{}

--- a/test_utils/utils.go
+++ b/test_utils/utils.go
@@ -70,7 +70,7 @@ func WipeK8sPods() {
 	}
 }
 
-func RunIPAMPlugin(netconf, command, args string) (types.Result, int) {
+func RunIPAMPlugin(netconf, command, args string) (types.Result, types.Error, int) {
 	conf := types.NetConf{}
 	if err := json.Unmarshal([]byte(netconf), &conf); err != nil {
 		panic(fmt.Errorf("failed to load netconf: %v", err))
@@ -97,17 +97,21 @@ func RunIPAMPlugin(netconf, command, args string) (types.Result, int) {
 	session.Wait(5)
 	exitCode := session.ExitCode()
 	result := types.Result{}
+	error := types.Error{}
 	stdout := session.Out.Contents()
 	if exitCode == 0 {
-
 		if command == "ADD" {
 			if err := json.Unmarshal(stdout, &result); err != nil {
 				panic(fmt.Errorf("failed to load result: %s %v", stdout, err))
 			}
 		}
+	} else {
+		if err := json.Unmarshal(stdout, &error); err != nil {
+			panic(fmt.Errorf("failed to load error: %s %v", stdout, err))
+		}
 	}
 
-	return result, exitCode
+	return result, error, exitCode
 }
 
 func CreateContainer(netconf string, k8sName string) (container_id, netnspath string, session *gexec.Session, contVeth netlink.Link, contAddr []netlink.Addr, contRoutes []netlink.Route, err error) {

--- a/utils/types.go
+++ b/utils/types.go
@@ -47,10 +47,12 @@ type NetConf struct {
 	Type string `json:"type"`
 	IPAM struct {
 		Name       string
-		Type       string  `json:"type"`
-		Subnet     string  `json:"subnet"`
-		AssignIpv4 *string `json:"assign_ipv4"`
-		AssignIpv6 *string `json:"assign_ipv6"`
+		Type       string   `json:"type"`
+		Subnet     string   `json:"subnet"`
+		AssignIpv4 *string  `json:"assign_ipv4"`
+		AssignIpv6 *string  `json:"assign_ipv6"`
+		IPv4Pools  []string `json:"ipv4_pools"`
+		IPv6Pools  []string `json:"ipv6_pools"`
 	} `json:"ipam,omitempty"`
 	MTU            int        `json:"mtu"`
 	Hostname       string     `json:"hostname"`

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -232,3 +232,23 @@ func CreateContextLogger(workload string) *log.Entry {
 
 	return contextLogger
 }
+
+// Takes as array of IPv4 or IPv6 pools and parses them into an array of IPnet's
+func ParsePools(pools []string, isv4 bool) ([]cnet.IPNet, error) {
+	result := []cnet.IPNet{}
+	for _, p := range pools {
+		_, cidr, err := net.ParseCIDR(p)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing pool %q: %s", p, err)
+		}
+		ip := cidr.IP
+		if isv4 && ip.To4() == nil {
+			return nil, fmt.Errorf("%q isn't a IPv4 address", ip)
+		}
+		if !isv4 && ip.To4() != nil {
+			return nil, fmt.Errorf("%q isn't a IPv16 address", ip)
+		}
+		result = append(result, cnet.IPNet{*cidr})
+	}
+	return result, nil
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -246,7 +246,7 @@ func ParsePools(pools []string, isv4 bool) ([]cnet.IPNet, error) {
 			return nil, fmt.Errorf("%q isn't a IPv4 address", ip)
 		}
 		if !isv4 && ip.To4() != nil {
-			return nil, fmt.Errorf("%q isn't a IPv16 address", ip)
+			return nil, fmt.Errorf("%q isn't a IPv6 address", ip)
 		}
 		result = append(result, cnet.IPNet{*cidr})
 	}


### PR DESCRIPTION
Now that https://github.com/projectcalico/libcalico-go/pull/271 is merged.

Bump refs to libcalico-go too

Add pod annotations to enable them:
```
    spec:
      template:
        metadata:
          annotations:
            cni.calico/ipv4pools: [<ip-pool-1>, <ip-pool-2>]
            cni.calico/ipv6pools: [<ip-pool-1>, <ip-pool-2>]
```

Signed-off-by: Doug Davis <dug@us.ibm.com>