### PR TITLE
Makefile: Use calico/go-build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.go-pkg-cache
 dist
 kubeconfig
 .idea

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,7 +1,0 @@
-FROM golang:1.7
-
-MAINTAINER Tom Denham <tom@tigera.io>
-
-RUN go get github.com/onsi/ginkgo/ginkgo
-WORKDIR /go/src/github.com/projectcalico/cni-plugin
-


### PR DESCRIPTION
- For vendoring
- For static checks
- For build binaries (and get a nice speedup from package cache)
- For tests