### PR TITLE
Don't fail fast for install-cni.sh

### DIFF
--- a/k8s-install/scripts/install-cni.sh
+++ b/k8s-install/scripts/install-cni.sh
@@ -5,8 +5,8 @@
 # - Expects the host CNI network config path to be mounted at /host/etc/cni/net.d.
 # - Expects the desired CNI config in the CNI_NETWORK_CONFIG env variable.
 
-# Ensure all variables are defined and that we fail fast.
-set -u -e
+# Ensure all variables are defined. 
+set -u 
 
 # The directory on the host where CNI networks are installed. Defaults to 
 # /etc/cni/net.d, but can be overridden by setting CNI_NET_DIR.  This is used


### PR DESCRIPTION
Stop failing fast - we expect some of the commands to fail sometimes. 

Not sure if this if the right fix long term, but this was a recent change so I'd like to revert it while we work out what to do longer term.