### PR TITLE
Insert serviceaccount token in the generated kubeconfig.

### DIFF
--- a/k8s-install/scripts/install-cni.sh
+++ b/k8s-install/scripts/install-cni.sh
@@ -106,6 +106,8 @@ clusters:
     insecure-skip-tls-verify: true
 users:
 - name: calico 
+  user:
+    token: "${SERVICEACCOUNT_TOKEN:-}"
 contexts:
 - name: calico-context
   context:


### PR DESCRIPTION
Haven't tested this yet, but intention is to start moving all the API connection details out of the network config and into the kubeconfig (given that specifying them in the CNI network is deprecated as per our docs).