### PR TITLE
Use labels instead of tags + tests

### DIFF
--- a/calico.go
+++ b/calico.go
@@ -222,19 +222,19 @@ func cmdAdd(args *skel.CmdArgs) error {
 		if !exists {
 			// The profile doesn't exist so needs to be created. The rules vary depending on whether k8s is being used.
 			// Under k8s (without full policy support) the rule is permissive and allows all traffic.
-			// Otherwise, incoming traffic is only allowed from profiles with the same tag.
+			// Otherwise, incoming traffic is only allowed from profiles with the same labels.
 			fmt.Fprintf(os.Stderr, "Calico CNI creating profile: %s\n", conf.Name)
 			var inboundRules []api.Rule
 			if orchestrator == "k8s" {
 				inboundRules = []api.Rule{{Action: "allow"}}
 			} else {
-				inboundRules = []api.Rule{{Action: "allow", Source: api.EntityRule{Tag: conf.Name}}}
+				inboundRules = []api.Rule{{Action: "allow", Source: api.EntityRule{Selector: fmt.Sprintf("projectcalico.org/network == %s", conf.Name)}}}
 			}
 
 			profile := &api.Profile{
 				Metadata: api.ProfileMetadata{
-					Name: conf.Name,
-					Tags: []string{conf.Name},
+					Name:   conf.Name,
+					Labels: map[string]string{"projectcalico.org/network": conf.Name},
 				},
 				Spec: api.ProfileSpec{
 					EgressRules:  []api.Rule{{Action: "allow"}},

--- a/calico.go
+++ b/calico.go
@@ -228,7 +228,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 			if orchestrator == "k8s" {
 				inboundRules = []api.Rule{{Action: "allow"}}
 			} else {
-				inboundRules = []api.Rule{{Action: "allow", Source: api.EntityRule{Selector: fmt.Sprintf("projectcalico.org/network == %s", conf.Name)}}}
+				inboundRules = []api.Rule{{Action: "allow", Source: api.EntityRule{Selector: fmt.Sprintf("projectcalico.org/network == \"%s\"", conf.Name)}}}
 			}
 
 			profile := &api.Profile{

--- a/calico_cni_test.go
+++ b/calico_cni_test.go
@@ -78,9 +78,9 @@ var _ = Describe("CalicoCni", func() {
 				// Profile is created with correct details
 				profile, err := calicoClient.Profiles().Get(api.ProfileMetadata{Name: "net1"})
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(profile.Metadata.Tags).Should(ConsistOf("net1"))
+				Expect(profile.Metadata.Labels).Should(HaveKeyWithValue("projectcalico.org/network", "net1"))
 				Expect(profile.Spec.EgressRules).Should(Equal([]api.Rule{{Action: "allow"}}))
-				Expect(profile.Spec.IngressRules).Should(Equal([]api.Rule{{Action: "allow", Source: api.EntityRule{Tag: "net1"}}}))
+				Expect(profile.Spec.IngressRules).Should(Equal([]api.Rule{{Action: "allow", Source: api.EntityRule{Selector: "projectcalico.org/network == net1"}}}))
 
 				// The endpoint is created in etcd
 				endpoints, err := calicoClient.WorkloadEndpoints().List(api.WorkloadEndpointMetadata{})

--- a/calico_cni_test.go
+++ b/calico_cni_test.go
@@ -80,7 +80,7 @@ var _ = Describe("CalicoCni", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(profile.Metadata.Labels).Should(HaveKeyWithValue("projectcalico.org/network", "net1"))
 				Expect(profile.Spec.EgressRules).Should(Equal([]api.Rule{{Action: "allow"}}))
-				Expect(profile.Spec.IngressRules).Should(Equal([]api.Rule{{Action: "allow", Source: api.EntityRule{Selector: "projectcalico.org/network == net1"}}}))
+				Expect(profile.Spec.IngressRules).Should(Equal([]api.Rule{{Action: "allow", Source: api.EntityRule{Selector: "projectcalico.org/network == \"net1\""}}}))
 
 				// The endpoint is created in etcd
 				endpoints, err := calicoClient.WorkloadEndpoints().List(api.WorkloadEndpointMetadata{})


### PR DESCRIPTION
`Tags` are deprecated, so in order to phase `Tags` out, we want to replace tags with `Labels` in all of our plugins where default `Profile` is created by the plugins (libnetwork-plugin and cni-plugin)