### PR TITLE
Don't error if things don't exist

### DIFF
--- a/calico_cni_ipam_test.go
+++ b/calico_cni_ipam_test.go
@@ -188,4 +188,20 @@ var _ = Describe("Calico IPAM Tests", func() {
 			})
 		})
 	})
+
+	Describe("Run IPAM DEL", func() {
+		netconf := fmt.Sprintf(`
+					{"name": "net1",
+					  "type": "calico",
+					  "etcd_endpoints": "http://%s:2379",
+					  "ipam": {
+					    "type": "%s"
+					  }
+					}`, os.Getenv("ETCD_IP"), plugin)
+
+		It("should exit successfully even if no address exists", func() {
+			_, _, exitCode := RunIPAMPlugin(netconf, "DEL", "IP=192.168.123.123")
+			Expect(exitCode).Should(Equal(0))
+		})
+	})
 })

--- a/calico_cni_k8s_test.go
+++ b/calico_cni_k8s_test.go
@@ -153,9 +153,8 @@ var _ = Describe("CalicoCni", func() {
 						Type:      syscall.RTN_UNICAST,
 					})))
 
-				session, err = DeleteContainer(netconf, netnspath, name)
+				_, err = DeleteContainer(netconf, netnspath, name)
 				Expect(err).ShouldNot(HaveOccurred())
-				Eventually(session).Should(gexec.Exit())
 
 				// Make sure there are no endpoints anymore
 				endpoints, err = calicoClient.WorkloadEndpoints().List(api.WorkloadEndpointMetadata{})
@@ -446,7 +445,7 @@ var _ = Describe("CalicoCni", func() {
 					requestedIP := "10.0.0.42"
 					expectedIP := net.IPv4(10, 0, 0, 42).To4()
 
-					_, netnspath, session, _, contAddresses, _, err := CreateContainer(netconfHostLocalIPAM, name, requestedIP)
+					_, netnspath, _, _, contAddresses, _, err := CreateContainer(netconfHostLocalIPAM, name, requestedIP)
 					Expect(err).NotTo(HaveOccurred())
 
 					podIP := contAddresses[0].IP
@@ -454,9 +453,8 @@ var _ = Describe("CalicoCni", func() {
 					Expect(podIP).Should(Equal(expectedIP))
 
 					By("Deleting the pod we created earlier")
-					session, err = DeleteContainer(netconfHostLocalIPAM, netnspath, name)
+					_, err = DeleteContainer(netconfHostLocalIPAM, netnspath, name)
 					Expect(err).ShouldNot(HaveOccurred())
-					Eventually(session).Should(gexec.Exit())
 
 					By("Creating a second pod with the same IP address as the first pod")
 					name2 := fmt.Sprintf("run2%d", rand.Uint32())
@@ -471,7 +469,7 @@ var _ = Describe("CalicoCni", func() {
 					})
 					Expect(err).NotTo(HaveOccurred())
 
-					_, netnspath, session, _, contAddresses, _, err = CreateContainer(netconfHostLocalIPAM, name2, requestedIP)
+					_, netnspath, _, _, contAddresses, _, err = CreateContainer(netconfHostLocalIPAM, name2, requestedIP)
 					Expect(err).NotTo(HaveOccurred())
 
 					pod2IP := contAddresses[0].IP

--- a/calico_cni_test.go
+++ b/calico_cni_test.go
@@ -128,9 +128,8 @@ var _ = Describe("CalicoCni", func() {
 						Type:      syscall.RTN_UNICAST,
 					})))
 
-				session, err = DeleteContainer(netconf, netnspath, "")
+				_, err = DeleteContainer(netconf, netnspath, "")
 				Expect(err).ShouldNot(HaveOccurred())
-				Eventually(session).Should(gexec.Exit())
 
 				// Make sure there are no endpoints anymore
 				endpoints, err = calicoClient.WorkloadEndpoints().List(api.WorkloadEndpointMetadata{})
@@ -190,9 +189,8 @@ var _ = Describe("CalicoCni", func() {
 					Orchestrator: "cni",
 				}))
 
-				session, err = DeleteContainer(netconf, netnspath, "")
+				_, err = DeleteContainer(netconf, netnspath, "")
 				Expect(err).ShouldNot(HaveOccurred())
-				Eventually(session).Should(gexec.Exit())
 			})
 		})
 	})
@@ -233,9 +231,8 @@ var _ = Describe("CalicoCni", func() {
 					Orchestrator: "cni",
 				}))
 
-				session, err = DeleteContainer(netconf, netnspath, "")
+				_, err = DeleteContainer(netconf, netnspath, "")
 				Expect(err).ShouldNot(HaveOccurred())
-				Eventually(session).Should(gexec.Exit())
 			})
 		})
 	})
@@ -255,9 +252,9 @@ var _ = Describe("CalicoCni", func() {
 		Context("when it was never called for SetUP", func() {
 			Context("and a namespace does exist", func() {
 				It("exits with 'success' error code", func() {
-					_, netnspath, err := CreateContainerNamespace()
+					_, _, netnspath, err := CreateContainerNamespace()
 					Expect(err).ShouldNot(HaveOccurred())
-					exitCode, err := CmdDel(netconf, netnspath, "")
+					exitCode, err := DeleteContainer(netconf, netnspath, "")
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(exitCode).To(Equal(0))
 				})
@@ -265,7 +262,7 @@ var _ = Describe("CalicoCni", func() {
 
 			Context("and no namespace exists", func() {
 				It("exits with 'success' error code", func() {
-					exitCode, err := CmdDel(netconf, "/not/a/real/path1234567890", "")
+					exitCode, err := DeleteContainer(netconf, "/not/a/real/path1234567890", "")
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(exitCode).To(Equal(0))
 				})

--- a/calico_cni_test.go
+++ b/calico_cni_test.go
@@ -239,4 +239,37 @@ var _ = Describe("CalicoCni", func() {
 			})
 		})
 	})
+
+	Describe("DEL", func() {
+		netconf := fmt.Sprintf(`
+		{
+			"name": "net1",
+			"type": "calico",
+			"etcd_endpoints": "http://%s:2379",
+			"ipam": {
+				"type": "host-local",
+				"subnet": "10.0.0.0/8"
+			}
+		}`, os.Getenv("ETCD_IP"))
+
+		Context("when it was never called for SetUP", func() {
+			Context("and a namespace does exist", func() {
+				It("exits with 'success' error code", func() {
+					_, netnspath, err := CreateContainerNamespace()
+					Expect(err).ShouldNot(HaveOccurred())
+					exitCode, err := CmdDel(netconf, netnspath, "")
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(exitCode).To(Equal(0))
+				})
+			})
+
+			Context("and no namespace exists", func() {
+				It("exits with 'success' error code", func() {
+					exitCode, err := CmdDel(netconf, "/not/a/real/path1234567890", "")
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(exitCode).To(Equal(0))
+				})
+			})
+		})
+	})
 })

--- a/ipam/calico-ipam.go
+++ b/ipam/calico-ipam.go
@@ -27,6 +27,7 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/projectcalico/cni-plugin/utils"
 	"github.com/projectcalico/libcalico-go/lib/client"
+	"github.com/projectcalico/libcalico-go/lib/errors"
 	cnet "github.com/projectcalico/libcalico-go/lib/net"
 )
 
@@ -193,6 +194,10 @@ func cmdDel(args *skel.CmdArgs) error {
 
 	logger.Info("Releasing address using workloadID")
 	if err := calicoClient.IPAM().ReleaseByHandle(workloadID); err != nil {
+		if _, ok := err.(errors.ErrorResourceDoesNotExist); ok {
+			logger.WithField("workloadId", workloadID).Warn("Asked to release address but it doesn't exist. Ignoring")
+			return nil
+		}
 		return err
 	}
 

--- a/test_utils/utils.go
+++ b/test_utils/utils.go
@@ -116,6 +116,27 @@ func RunIPAMPlugin(netconf, command, args string) (types.Result, types.Error, in
 	return result, error, exitCode
 }
 
+func CreateContainerNamespace() (containerId, netnspath string, err error) {
+	containerNs, err := ns.NewNS()
+	if err != nil {
+		return "", "", err
+	}
+
+	netnspath = containerNs.Path()
+	netnsname := path.Base(netnspath)
+	containerId = netnsname[:10]
+
+	err = containerNs.Do(func(_ ns.NetNS) error {
+		lo, err := netlink.LinkByName("lo")
+		if err != nil {
+			return err
+		}
+		return netlink.LinkSetUp(lo)
+	})
+
+	return
+}
+
 func CreateContainer(netconf string, k8sName string, ip string) (container_id, netnspath string, session *gexec.Session, contVeth netlink.Link, contAddr []netlink.Addr, contRoutes []netlink.Route, err error) {
 	targetNs, err := ns.NewNS()
 	if err != nil {
@@ -184,6 +205,40 @@ func CreateContainer(netconf string, k8sName string, ip string) (container_id, n
 
 		return nil
 	})
+	return
+}
+
+// Executes the Calico CNI plugin and return the error code of the command.
+func CmdDel(netconf, netnspath, name string) (exitCode int, err error) {
+	netnsname := path.Base(netnspath)
+	container_id := netnsname[:10]
+	var k8s_env = ""
+	if name != "" {
+		k8s_env = fmt.Sprintf("CNI_ARGS=\"K8S_POD_NAME=%s;K8S_POD_NAMESPACE=test;K8S_POD_INFRA_CONTAINER_ID=whatever\"", name)
+	}
+
+	// Set up the env for running the CNI plugin
+	cni_env := fmt.Sprintf("CNI_COMMAND=DEL CNI_CONTAINERID=%s CNI_NETNS=%s CNI_IFNAME=eth0 CNI_PATH=dist %s", container_id, netnspath, k8s_env)
+
+	// Run the CNI plugin passing in the supplied netconf
+	subProcess := exec.Command("bash", "-c", fmt.Sprintf("%s dist/%s", cni_env, os.Getenv("PLUGIN")), netconf)
+	stdin, err := subProcess.StdinPipe()
+	if err != nil {
+		return
+	}
+	io.WriteString(stdin, netconf)
+	io.WriteString(stdin, "\n")
+	stdin.Close()
+
+	session, err := gexec.Start(subProcess, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
+	if err != nil {
+		return
+	}
+
+	// Wait should supposedly induce a test failure if it times out?
+	session.Wait(5)
+
+	exitCode = session.ExitCode()
 	return
 }
 


### PR DESCRIPTION
Fixes #287 

This PR enables the CNI plugin to gracefully "Delete" a container that it it never "Setup". It does this by not erroring out if the resources it was called against do not exist, be it resources in the etcd datastore, or devices in the namespace it was given.

This resolves a condition that has popped up in K8s 1.6 where Kubernetes seems to lock a container in "ContainerCreating" status when Calico errors a CNI teardown request. This request was errored because Calico was never given a Create request.

This PR should also help scenarios in the future where Calico may have only half-completed a SetUp request or was called to teardown  a dirty environment.

WIP. Please don't review yet, will clean up tomorrow a.m.