### PR TITLE
Bundle newer CNI binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ fetch-cni-bins: dist/flannel dist/loopback dist/host-local
 
 dist/flannel dist/loopback dist/host-local:
 	mkdir -p dist
-	$(CURL) -L --retry 5 https://github.com/containernetworking/cni/releases/download/v0.4.0/cni-amd64-v0.4.0.tgz | tar -xz -C dist ./flannel ./loopback ./host-local
+	$(CURL) -L --retry 5 https://github.com/containernetworking/cni/releases/download/v0.5.1/cni-amd64-v0.5.1.tgz | tar -xz -C dist ./flannel ./loopback ./host-local
 
 # Useful for CI but currently slow for local development because the
 # .go-pkg-cache can't be used (since tests run as root)

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ LOCAL_IP_ENV?=$(shell ip route get 8.8.8.8 | head -1 | awk '{print $$7}')
 CURL=curl -sSf
 
 K8S_VERSION=1.5.4
+CNI_VERSION=v0.5.1
 
 CALICO_CNI_VERSION?=$(shell git describe --tags --dirty)
 
@@ -107,7 +108,7 @@ fetch-cni-bins: dist/flannel dist/loopback dist/host-local
 
 dist/flannel dist/loopback dist/host-local:
 	mkdir -p dist
-	$(CURL) -L --retry 5 https://github.com/containernetworking/cni/releases/download/v0.5.1/cni-amd64-v0.5.1.tgz | tar -xz -C dist ./flannel ./loopback ./host-local
+	$(CURL) -L --retry 5 https://github.com/containernetworking/cni/releases/download/$(CNI_VERSION)/cni-amd64-$(CNI_VERSION).tgz | tar -xz -C dist ./flannel ./loopback ./host-local
 
 # Useful for CI but currently slow for local development because the
 # .go-pkg-cache can't be used (since tests run as root)


### PR DESCRIPTION
Tested with a kubernetes 1.6 cluster kicked up with kubeadm.

Confirmed that updated flannel now handles teardowns correctly for pods it didn't setup.