### PR TITLE
Add sysctl and route programming to CNI + tests

### DIFF
--- a/utils/network.go
+++ b/utils/network.go
@@ -2,7 +2,9 @@ package utils
 
 import (
 	"fmt"
+	"io"
 	"net"
+	"os"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/containernetworking/cni/pkg/ip"
@@ -15,8 +17,9 @@ import (
 // DoNetworking performs the networking for the given config and IPAM result
 func DoNetworking(args *skel.CmdArgs, conf NetConf, result *current.Result, logger *log.Entry, desiredVethName string) (hostVethName, contVethMAC string, err error) {
 	// Select the first 11 characters of the containerID for the host veth.
-	hostVethName = "cali" + args.ContainerID[:min(11, len(args.ContainerID))]
+	hostVethName = "cali" + args.ContainerID[:Min(11, len(args.ContainerID))]
 	contVethName := args.IfName
+	var hasIPv4, hasIPv6 bool
 
 	// If a desired veth name was passed in, use that instead.
 	if desiredVethName != "" {
@@ -92,7 +95,9 @@ func DoNetworking(args *skel.CmdArgs, conf NetConf, result *current.Result, logg
 				if err = netlink.AddrAdd(contVeth, &netlink.Addr{IPNet: &addr.Address}); err != nil {
 					return fmt.Errorf("failed to add IP addr to %q: %v", contVethName, err)
 				}
-
+				// Set hasIPv4 to true so sysctls for IPv4 can be programmed when the host side of
+				// the veth finishes moving to the host namespace.
+				hasIPv4 = true
 			}
 
 			// Handle IPv6 routes
@@ -110,7 +115,7 @@ func DoNetworking(args *skel.CmdArgs, conf NetConf, result *current.Result, logg
 					// If the hostVeth doesn't have an IPv6 address then this host probably doesn't
 					// support IPv6. Since a IPv6 address has been allocated that can't be used,
 					// return an error.
-					return fmt.Errorf("Failed to get IPv6 addresses for host side of the veth pair")
+					return fmt.Errorf("failed to get IPv6 addresses for host side of the veth pair")
 				}
 
 				hostIPv6Addr := addresses[0].IP
@@ -123,6 +128,10 @@ func DoNetworking(args *skel.CmdArgs, conf NetConf, result *current.Result, logg
 				if err = netlink.AddrAdd(contVeth, &netlink.Addr{IPNet: &addr.Address}); err != nil {
 					return fmt.Errorf("failed to add IP addr to %q: %v", contVeth, err)
 				}
+
+				// Set hasIPv6 to true so sysctls for IPv6 can be programmed when the host side of
+				// the veth finishes moving to the host namespace.
+				hasIPv6 = true
 			}
 		}
 
@@ -140,6 +149,11 @@ func DoNetworking(args *skel.CmdArgs, conf NetConf, result *current.Result, logg
 		return "", "", err
 	}
 
+	err = configureSysctls(hostVethName, hasIPv4, hasIPv6)
+	if err != nil {
+		return "", "", fmt.Errorf("error configuring sysctls for interface: %s, error: %s", hostVethName, err)
+	}
+
 	// Moving a veth between namespaces always leaves it in the "DOWN" state. Set it back to "UP" now that we're
 	// back in the host namespace.
 	hostVeth, err := netlink.LinkByName(hostVethName)
@@ -151,5 +165,91 @@ func DoNetworking(args *skel.CmdArgs, conf NetConf, result *current.Result, logg
 		return "", "", fmt.Errorf("failed to set %q up: %v", hostVethName, err)
 	}
 
+	// Now that the host side of the veth is moved, state set to UP, and configured with sysctls, we can add the routes to it in the host namespace.
+	err = setupRoutes(hostVeth, result)
+	if err != nil {
+		return "", "", fmt.Errorf("error adding host side routes for interface: %s, error: %s", hostVeth.Attrs().Name, err)
+	}
+
 	return hostVethName, contVethMAC, err
+}
+
+// setupRoutes sets up the routes for the host side of the veth pair.
+func setupRoutes(hostVeth netlink.Link, result *current.Result) error {
+	for _, ip := range result.IPs {
+		err := netlink.RouteAdd(
+			&netlink.Route{
+				LinkIndex: hostVeth.Attrs().Index,
+				Scope:     netlink.SCOPE_LINK,
+				Dst:       &ip.Address,
+			})
+		if err != nil {
+			return fmt.Errorf("failed to add route %v", err)
+		}
+
+		log.Debugf("CNI adding route for interface: %v, IP: %s", hostVeth, ip.Address)
+	}
+	return nil
+}
+
+// configureSysctls configures necessary sysctls required for the host side of the veth pair for IPv4 and/or IPv6.
+func configureSysctls(hostVethName string, hasIPv4, hasIPv6 bool) error {
+	var err error
+
+	if hasIPv4 {
+		// Enable proxy ARP, this makes the host respond to all ARP requests with its own
+		// MAC. We install explicit routes into the containers network
+		// namespace and we use a link-local address for the gateway.  Turing on proxy ARP
+		// means that we don't need to assign the link local address explicitly to each
+		// host side of the veth, which is one fewer thing to maintain and one fewer
+		// thing we may clash over.
+		if err = writeProcSys(fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/proxy_arp", hostVethName), "1"); err != nil {
+			return err
+		}
+
+		// Normally, the kernel has a delay before responding to proxy ARP but we know
+		// that's not needed in a Calico network so we disable it.
+		if err = writeProcSys(fmt.Sprintf("/proc/sys/net/ipv4/neigh/%s/proxy_delay", hostVethName), "0"); err != nil {
+			return err
+		}
+
+		// Enable IP forwarding of packets coming _from_ this interface.  For packets to
+		// be forwarded in both directions we need this flag to be set on the fabric-facing
+		// interface too (or for the global default to be set).
+		if err = writeProcSys(fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/forwarding", hostVethName), "1"); err != nil {
+			return err
+		}
+	}
+
+	if hasIPv6 {
+		// Enable proxy NDP, similarly to proxy ARP, described above in IPv4 section.
+		if err = writeProcSys(fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/proxy_ndp", hostVethName), "1"); err != nil {
+			return err
+		}
+
+		// Enable IP forwarding of packets coming _from_ this interface.  For packets to
+		// be forwarded in both directions we need this flag to be set on the fabric-facing
+		// interface too (or for the global default to be set).
+		if err = writeProcSys(fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/forwarding", hostVethName), "1"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// writeProcSys takes the sysctl path and a string value to set i.e. "0" or "1" and sets the sysctl.
+func writeProcSys(path, value string) error {
+	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	n, err := f.Write([]byte(value))
+	if err == nil && n < len(value) {
+		err = io.ErrShortWrite
+	}
+	if err1 := f.Close(); err == nil {
+		err = err1
+	}
+	return err
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -37,7 +37,7 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
-func min(a, b int) int {
+func Min(a, b int) int {
 	if a < b {
 		return a
 	}


### PR DESCRIPTION
fixes #306 
Calico CNI relies on Felix to configure host side route(s) and sysctls for the host veth for the pod currently, with this Calico CNI should be able to do that itself.

Route programming and interface sysctl config happens during ADD, and gets destroyed with DEL as the interface gets removed, which removes routes and sysctls. 