### PR TITLE
Add portmap plugin

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,4 @@
 !dist/flannel
 !dist/loopback
 !dist/host-local
+!dist/portmap

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ADD dist/calico /opt/cni/bin/calico
 ADD dist/flannel /opt/cni/bin/flannel
 ADD dist/loopback /opt/cni/bin/loopback
 ADD dist/host-local /opt/cni/bin/host-local
+ADD dist/portmap /opt/cni/bin/portmap
 ADD dist/calico-ipam /opt/cni/bin/calico-ipam
 ADD k8s-install/scripts/install-cni.sh /install-cni.sh
 ADD k8s-install/scripts/calico.conf.default /calico.conf.tmp

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,13 @@ $(DEPLOY_CONTAINER_MARKER): Dockerfile build-containerized fetch-cni-bins
 	touch $@
 
 .PHONY: fetch-cni-bins
-fetch-cni-bins: dist/flannel dist/loopback dist/host-local
+fetch-cni-bins: dist/flannel dist/loopback dist/host-local dist/portmap
+
+# For now we've got a checked in version of the plugin.  Eventually
+# this should pull from upstream releases.
+dist/portmap:
+	mkdir -p dist
+	$(CURL) -L https://github.com/projectcalico/cni-plugin/releases/download/v1.8.3/portmap -o $@
 
 dist/flannel dist/loopback dist/host-local:
 	mkdir -p dist

--- a/k8s-install/scripts/install-cni.sh
+++ b/k8s-install/scripts/install-cni.sh
@@ -62,6 +62,9 @@ if [ -w "/host/opt/cni/bin/" ]; then
 	if [ ! -f /host/opt/cni/bin/host-local ]; then
 	    cp /opt/cni/bin/host-local /host/opt/cni/bin/
 	fi
+	if [ ! -f /host/opt/cni/bin/portmap ]; then
+	    cp /opt/cni/bin/portmap /host/opt/cni/bin/
+	fi
 	echo "Wrote Calico CNI binaries to /host/opt/cni/bin/"
 	echo "CNI plugin version: $(/host/opt/cni/bin/calico -v)"
 fi
@@ -80,6 +83,9 @@ if [ -w "/host/secondary-bin-dir/" ]; then
 	fi
 	if [ ! -f /host/secondary-bin-dir/host-local ]; then
 	    cp /opt/cni/bin/host-local /host/secondary-bin-dir/
+	fi
+	if [ ! -f /host/secondary-bin-dir/portmap ]; then
+	    cp /opt/cni/bin/portmap /host/secondary-bin-dir/
 	fi
 	echo "Wrote Calico CNI binaries to /host/secondary-bin-dir/"
 	echo "CNI plugin version: $(/host/secondary-bin-dir/calico -v)"


### PR DESCRIPTION
## Description
Adds the portmap plugin from https://github.com/containernetworking/plugins/pull/1 to the cni installer.  Currently, there is no release of the portmap plugin so this PR needs to wait until there is one.

## Todos
- [x] Include portmap plugin, or reference upstream release.
- [ ] Documentation

