### PR TITLE
Make CNI resilient to an already existing route

### DIFF
--- a/calico_cni_k8s_test.go
+++ b/calico_cni_k8s_test.go
@@ -576,7 +576,7 @@ var _ = Describe("CalicoCni", func() {
 			})
 
 			Context("Using host-local IPAM: request an IP then release it, and then request it again", func() {
-				It("Should successfully assign IP both times and successfully release it in the middle", func() {
+				It("should successfully assign IP both times and successfully release it in the middle", func() {
 					netconfHostLocalIPAM := fmt.Sprintf(`
 				  {
 					"cniVersion": "%s",

--- a/calico_cni_test.go
+++ b/calico_cni_test.go
@@ -390,4 +390,63 @@ var _ = Describe("CalicoCni", func() {
 			})
 		})
 	})
+
+	Describe("CNI should be resilient to an already existing route", func() {
+		Context("add a new container when the route already exists  ", func() {
+			netconf := fmt.Sprintf(`
+			{
+			  "cniVersion": "%s",
+			  "name": "net1",
+			  "type": "calico",
+			  "etcd_endpoints": "http://%s:2379",
+			  "ipam": {
+			    "type": "host-local",
+			    "subnet": "10.0.0.0/24"
+			  }
+			}`, cniVersion, os.Getenv("ETCD_IP"))
+
+			It("should successfully add and network the container", func() {
+				containerIPStr := "10.0.0.55"
+				_, containerIP, _ := net.ParseCIDR("10.0.0.55/32")
+
+				By("Manually programming the route that CNI plugin is going to add.")
+				netlink.RouteAdd(
+					&netlink.Route{
+						Scope: netlink.SCOPE_LINK,
+						Dst:   containerIP,
+					})
+
+				By("Calling the CNI plugin requesting the same IP, so CNI would try to add the same route.")
+				containerID, session, _, _, _, contNs, err := CreateContainer(netconf, "", containerIPStr)
+				Expect(err).ShouldNot(HaveOccurred())
+				Eventually(session).Should(gexec.Exit())
+
+				result, err := GetResultForCurrent(session, cniVersion)
+				if err != nil {
+					log.Fatalf("Error getting result from the session: %v\n", err)
+				}
+
+				log.Printf("Unmarshalled result from first ADD: %v\n", result)
+
+				// The endpoint should be created in the backend
+				endpoints, err := calicoClient.WorkloadEndpoints().List(api.WorkloadEndpointMetadata{})
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(endpoints.Items).Should(HaveLen(1))
+
+				// Set the Revision to nil since we can't assert it's exact value.
+				endpoints.Items[0].Metadata.Revision = nil
+				Expect(endpoints.Items[0].Metadata).Should(Equal(api.WorkloadEndpointMetadata{
+					Node:             hostname,
+					Name:             "eth0",
+					Workload:         containerID,
+					ActiveInstanceID: "",
+					Orchestrator:     "cni",
+				}))
+
+				By("Deleting the container we created.")
+				_, err = DeleteContainer(netconf, contNs.Path(), "")
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+		})
+	})
 })


### PR DESCRIPTION
## Description
Fixes #352
CNI fails to setup network for the container/pod if the route already exists.

## Todos
- [x] Tests
- [x] Release note

## Release Note
```release-note
Fix for a bug where CNI network setup fails if the route already existed on the host.
```
