### PR TITLE
Wrap description in comment for contributors

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,14 @@
 ## Description
-A few sentences describing the overall goals of the pull request's commits.
+<!-- A few sentences describing the overall goals of the pull request's commits.
 Please include
 - the type of fix - (e.g. bug fix, new feature, documentation)
 - some details on _why_ this PR should be merged
 - the details of the testing you've done on it (both manual and automated)
 - which components are affected by this PR
 - links to issues that this PR addresses
+-->
+
+
 
 ## Todos
 - [ ] Tests


### PR DESCRIPTION
## Description
The description for PR's isn't wrapped in a comment which is inconsistent with the release notes section below, and a bit more of a pain as users have to delete that section to fill it in.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
