### PR TITLE
Added dynamic log level

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,7 @@ ADD dist/calico-ipam /opt/cni/bin/calico-ipam
 ADD k8s-install/scripts/install-cni.sh /install-cni.sh
 ADD k8s-install/scripts/calico.conf.default /calico.conf.tmp
 
-ENV PATH=$PATH:/opt/cni/bin \
-    LOG_LEVEL=warn
+ENV PATH=$PATH:/opt/cni/bin
 VOLUME /opt/cni
 WORKDIR /opt/cni/bin
 CMD ["/opt/cni/bin/calico"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ ADD dist/calico-ipam /opt/cni/bin/calico-ipam
 ADD k8s-install/scripts/install-cni.sh /install-cni.sh
 ADD k8s-install/scripts/calico.conf.default /calico.conf.tmp
 
-ENV PATH=$PATH:/opt/cni/bin
+ENV PATH=$PATH:/opt/cni/bin \
+    LOG_LEVEL=warn
 VOLUME /opt/cni
 WORKDIR /opt/cni/bin
 CMD ["/opt/cni/bin/calico"]

--- a/k8s-install/scripts/calico.conf.default
+++ b/k8s-install/scripts/calico.conf.default
@@ -5,7 +5,7 @@
     "etcd_key_file": "__ETCD_KEY_FILE__",
     "etcd_cert_file": "__ETCD_CERT_FILE__",
     "etcd_ca_cert_file": "__ETCD_CA_CERT_FILE__",
-    "log_level": "info",
+    "log_level": "__LOG_LEVEL__",
     "ipam": {
         "type": "calico-ipam"
     },

--- a/k8s-install/scripts/install-cni.sh
+++ b/k8s-install/scripts/install-cni.sh
@@ -125,7 +125,7 @@ sed -i s~__ETCD_CERT_FILE__~${CNI_CONF_ETCD_CERT:-}~g $TMP_CONF
 sed -i s~__ETCD_KEY_FILE__~${CNI_CONF_ETCD_KEY:-}~g $TMP_CONF
 sed -i s~__ETCD_CA_CERT_FILE__~${CNI_CONF_ETCD_CA:-}~g $TMP_CONF
 sed -i s~__ETCD_ENDPOINTS__~${ETCD_ENDPOINTS:-}~g $TMP_CONF
-sed -i s~__LOG_LEVEL__~${LOG_LEVEL}~g $TMP_CONF
+sed -i s~__LOG_LEVEL__~${LOG_LEVEL:-warn}~g $TMP_CONF
 
 # Move the temporary CNI config into place.
 FILENAME=${CNI_CONF_NAME:-10-calico.conf}

--- a/k8s-install/scripts/install-cni.sh
+++ b/k8s-install/scripts/install-cni.sh
@@ -125,6 +125,7 @@ sed -i s~__ETCD_CERT_FILE__~${CNI_CONF_ETCD_CERT:-}~g $TMP_CONF
 sed -i s~__ETCD_KEY_FILE__~${CNI_CONF_ETCD_KEY:-}~g $TMP_CONF
 sed -i s~__ETCD_CA_CERT_FILE__~${CNI_CONF_ETCD_CA:-}~g $TMP_CONF
 sed -i s~__ETCD_ENDPOINTS__~${ETCD_ENDPOINTS:-}~g $TMP_CONF
+sed -i s~__LOG_LEVEL__~${LOG_LEVEL}~g $TMP_CONF
 
 # Move the temporary CNI config into place.
 FILENAME=${CNI_CONF_NAME:-10-calico.conf}


### PR DESCRIPTION
These changes give the user the possibility to change calico's log level.
The log level can be changed by launching the container with the `LOG_LEVEL` environment variable containing the desired level.

This commit affects the calico.conf.default template to add a placeholder for the log level. It changes the install-cni.sh script and add the sed command to add the log level.

Finally it also provides a default value for the log-level as an env variable in the Dockerfile.

## Todos
- [x] Tests: It tested it locally and the templating stuff works
- [x] Documentation: I don't think documentation is needed, if someone think there should be, please advice me
- [x] Release note: See below

## Changelog
```release-note
#367 - Added configurable log level: Changes default behavior of the container by setting the log level to warn by default. To override this you can set it to info by launching the container with as environment variable: `LOG_LEVEL` to `info` (or whatever other valid level you want)
```

