### PR TITLE
Disable IP forwarding inside the container netns.

### DIFF
--- a/utils/network.go
+++ b/utils/network.go
@@ -142,15 +142,14 @@ func DoNetworking(args *skel.CmdArgs, conf NetConf, result *current.Result, logg
 			}
 		}
 
+		if err = configureContainerSysctls(hasIPv4, hasIPv6); err != nil {
+			return fmt.Errorf("error configuring sysctls for the container netns, error: %s", err)
+		}
+
 		// Now that the everything has been successfully set up in the container, move the "host" end of the
 		// veth into the host namespace.
 		if err = netlink.LinkSetNsFd(hostVeth, int(hostNS.Fd())); err != nil {
 			return fmt.Errorf("failed to move veth to host netns: %v", err)
-		}
-
-		err = configureContainerSysctls(hasIPv4, hasIPv6)
-		if err != nil {
-			return fmt.Errorf("error configuring sysctls for the container netns, error: %s", err)
 		}
 
 		return nil


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This PR disables ip forwarding inside the container netns. By default it is enabled, because it's inherited from the host netns.

My use case for this is running containers that accept network traffic for analysis.

I'm running a container with Snort IDS in it. I have some iptables rules on the host that duplicate the traffic with `TEE` to the container. The container is seeing the traffic is not destined to it, and is routing it back out the container interface. This then causes martian source errors in the host, and is pointless overall.

I think there are pretty much no downsides to disabling this: Containers only have 1 interface, so only difference this can make is that incoming packets can no longer be routed out the single interface. I really can't think of a reason you'd want this.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Disable IP forwarding inside the container netns.
```
