### PR TITLE
Always update the active instance ID

### DIFF
--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -242,7 +242,6 @@ func CmdAddK8s(args *skel.CmdArgs, conf utils.NetConf, nodename string, calicoCl
 		endpoint = api.NewWorkloadEndpoint()
 		endpoint.Metadata.Name = args.IfName
 		endpoint.Metadata.Node = nodename
-		endpoint.Metadata.ActiveInstanceID = args.ContainerID
 		endpoint.Metadata.Orchestrator = orchestrator
 		endpoint.Metadata.Workload = workload
 		endpoint.Metadata.Labels = labels
@@ -285,7 +284,8 @@ func CmdAddK8s(args *skel.CmdArgs, conf utils.NetConf, nodename string, calicoCl
 	}
 	endpoint.Spec.MAC = &cnet.MAC{HardwareAddr: mac}
 	endpoint.Spec.InterfaceName = hostVethName
-	logger.WithField("endpoint", endpoint).Info("Added Mac and interface name to endpoint")
+	endpoint.Metadata.ActiveInstanceID = args.ContainerID
+	logger.WithField("endpoint", endpoint).Info("Added Mac, interface name, and active container ID to endpoint")
 
 	// Write the endpoint object (either the newly created one, or the updated one)
 	if _, err := calicoClient.WorkloadEndpoints().Apply(endpoint); err != nil {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

We don't always update the ActiveInstanceID on workload endpoints when handling an ADD call.

This results in a scenario like so:

1) ADD for Pod X with container ID A
2) ADD for Pod X with container ID B
3) DEL for Pod X with container ID A

Since step 2 doesn't update the active instance ID, the workload endpoint gets deleted in step 3 even though there is an actively running container / Pod for that wep.

Fixes https://github.com/projectcalico/calico/issues/1117

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fixed a bug where running Kubernetes Pods could end up without corresponding workload endpoints in the datastore
```
