### PR TITLE
Adding tests for install-cni.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ delstats
 *.pyc
 *.created
 tmp-cni
+k8s-install/scripts/tmp/
+install_cni.test

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ docker-image: $(DEPLOY_CONTAINER_MARKER)
 
 .PHONY: clean
 clean:
-	rm -rf dist vendor $(DEPLOY_CONTAINER_MARKER) .go-pkg-cache
+	rm -rf dist vendor $(DEPLOY_CONTAINER_MARKER) .go-pkg-cache k8s-install/scripts/install_cni.test
 
 release: clean
 ifndef VERSION
@@ -92,7 +92,7 @@ dist/calico-ipam: $(SRCFILES) vendor
 
 .PHONY: test
 ## Run the unit tests.
-test: dist/calico dist/calico-ipam dist/host-local run-etcd run-k8s-apiserver
+test: dist/calico dist/calico-ipam dist/host-local run-etcd run-k8s-apiserver test-install-cni
 	# The tests need to run as root
 	sudo CGO_ENABLED=0 ETCD_IP=127.0.0.1 PLUGIN=calico GOPATH=$(GOPATH) $(shell which ginkgo)
 
@@ -129,6 +129,22 @@ test-containerized: run-etcd run-k8s-apiserver build-containerized dist/host-loc
 			ginkgo'
 	make stop-etcd
 
+# We pre-build the test binary so that we can run it outside a container and allow it
+# to interact with docker.
+k8s-install/scripts/install_cni.test: vendor
+	-mkdir -p .go-pkg-cache
+	docker run --rm \
+	-e LOCAL_USER_ID=$(LOCAL_USER_ID) \
+	-v $(CURDIR):/go/src/github.com/projectcalico/cni-plugin:rw \
+	-v $(CURDIR)/.go-pkg-cache:/go/pkg/:rw \
+		$(CALICO_BUILD) sh -c '\
+			cd /go/src/github.com/projectcalico/cni-plugin && \
+			go test ./k8s-install/scripts -c --tags install_cni_test -o ./k8s-install/scripts/install_cni.test'
+
+.PHONY: test-install-cni
+## Test the install-cni.sh script
+test-install-cni: docker-image k8s-install/scripts/install_cni.test
+	cd k8s-install/scripts && ./install_cni.test
 
 run-test-containerized-without-building: run-etcd run-k8s-apiserver
 	docker run --rm --privileged --net=host \
@@ -163,7 +179,7 @@ build-containerized: vendor
 		$(CALICO_BUILD) sh -c '\
 			cd /go/src/github.com/projectcalico/cni-plugin && \
 			make binary'
-	
+
 ## Etcd is used by the tests
 run-etcd: stop-etcd
 	docker run --detach \
@@ -294,7 +310,7 @@ run-kube-proxy:
 	-docker rm -f calico-kube-proxy
 	docker run --name calico-kube-proxy -d --net=host --privileged gcr.io/google_containers/hyperkube:v$(K8S_VERSION) /hyperkube proxy --master=http://127.0.0.1:8080 --v=2
 
-ci: clean static-checks test-containerized-cni-versions docker-image
+ci: clean static-checks test-containerized-cni-versions docker-image test-install-cni
 
 .PHONY: help
 help: # Some kind of magic from https://gist.github.com/rcmachado/af3db315e31383502660

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 8ef3cb64891b9ebbbec46ec6d32c4f4301d4ba7c434f073ad70bfd7419de1497
-updated: 2017-09-24T16:51:30.490503721-07:00
+hash: 1f0054fc8ba4c8880b804f5751aee427db43130dcb682245e75814d2b6124df5
+updated: 2017-09-29T13:44:09.386041992-07:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -152,6 +152,11 @@ imports:
   - matchers/support/goraph/node
   - matchers/support/goraph/util
   - types
+- name: github.com/projectcalico/felix
+  version: 4006dd5a3dfdd39bc0087a9e0a7e2f7623432de4
+  subpackages:
+  - fv
+  - fv.containers
 - name: github.com/projectcalico/go-json
   version: 6219dc7339ba20ee4c57df0a8baac62317d19cb1
   subpackages:
@@ -190,7 +195,7 @@ imports:
   - lib/testutils
   - lib/validator
 - name: github.com/prometheus/client_golang
-  version: c5b7fccd204277076155f10851dad72b76a49317
+  version: 967789050ba94deca04a5e84cce8ad472ce313c1
   subpackages:
   - prometheus
 - name: github.com/prometheus/client_model

--- a/glide.yaml
+++ b/glide.yaml
@@ -35,3 +35,7 @@ import:
   - kubernetes
   - tools/clientcmd
 - package: github.com/mcuadros/go-version
+- package: github.com/projectcalico/felix
+  subpackages:
+  - fv
+  - fv.containers

--- a/k8s-install/scripts/expected_10-calico.conf
+++ b/k8s-install/scripts/expected_10-calico.conf
@@ -1,0 +1,20 @@
+{
+    "name": "k8s-pod-network",
+    "type": "calico",
+    "etcd_endpoints": "",
+    "etcd_key_file": "",
+    "etcd_cert_file": "",
+    "etcd_ca_cert_file": "",
+    "log_level": "warn",
+    "ipam": {
+        "type": "calico-ipam"
+    },
+    "policy": {
+        "type": "k8s",
+        "k8s_api_root": "https://127.0.0.1:8080",
+        "k8s_auth_token": "my-secret-key"
+    },
+    "kubernetes": {
+        "kubeconfig": "/etc/cni/net.d/calico-kubeconfig"
+    }
+}

--- a/k8s-install/scripts/install-cni.sh
+++ b/k8s-install/scripts/install-cni.sh
@@ -5,8 +5,8 @@
 # - Expects the host CNI network config path to be mounted at /host/etc/cni/net.d.
 # - Expects the desired CNI config in the CNI_NETWORK_CONFIG env variable.
 
-# Ensure all variables are defined.
-set -u
+# Ensure all variables are defined, and that the script fails when an error is hit.
+set -u -e
 
 # The directory on the host where CNI networks are installed. Defaults to
 # /etc/cni/net.d, but can be overridden by setting CNI_NET_DIR.  This is used

--- a/k8s-install/scripts/install_cni_test.go
+++ b/k8s-install/scripts/install_cni_test.go
@@ -1,0 +1,204 @@
+package scripts_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/projectcalico/felix/fv/containers"
+
+	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+)
+
+var secretFile = "tmp/serviceaccount/token"
+
+// runCniContainer will run install-cni.sh.
+// TODO: We should be returning an error if the command fails, there currently is
+// not a way to get that from the container package.
+func runCniContainer(extraArgs ...string) error {
+	// Get the CWD for mounting directories into container.
+	cwd, err := os.Getwd()
+	if err != nil {
+		Fail("Could not get CWD")
+	}
+
+	// Assemble our arguments.
+	args := []string{
+		"-e", "SLEEP=false",
+		"-e", "KUBERNETES_SERVICE_HOST=127.0.0.1",
+		"-e", "KUBERNETES_SERVICE_PORT=8080",
+		"-v", cwd + "/tmp/bin:/host/opt/cni/bin",
+		"-v", cwd + "/tmp/net.d:/host/etc/cni/net.d",
+		"-v", cwd + "/tmp/serviceaccount:/var/run/secrets/kubernetes.io/serviceaccount",
+	}
+	args = append(args, extraArgs...)
+	args = append(args, "calico/cni:latest", "/install-cni.sh")
+
+	c := containers.Run("cni", args...)
+	Eventually(func() bool { return c.Stopped() }, 5*time.Second, 100*time.Millisecond).Should(BeTrue())
+
+	return nil
+}
+
+// cleanup uses the calico/cni container to cleanup after itself as it creates
+// things as root.
+func cleanup() {
+	cwd, err := os.Getwd()
+	if err != nil {
+		Fail("Could not get CWD")
+	}
+	containers.Run("cni",
+		"-e", "SLEEP=false",
+		"-e", "KUBERNETES_SERVICE_HOST=127.0.0.1",
+		"-e", "KUBERNETES_SERVICE_PORT=8080",
+		"-v", cwd+"/tmp/bin:/host/opt/cni/bin",
+		"-v", cwd+"/tmp/net.d:/host/etc/cni/net.d",
+		"-v", cwd+"/tmp/serviceaccount:/var/run/secrets/kubernetes.io/serviceaccount",
+		"calico/cni:latest",
+		"sh", "-c", "rm -f /host/opt/cni/bin/* /host/etc/cni/net.d/*")
+}
+
+var _ = BeforeSuite(func() {
+	// Make the directories we'll need for storing files.
+	err := os.MkdirAll("tmp/bin", 0755)
+	if err != nil {
+		Fail("Failed to create directory tmp/bin")
+	}
+	err = os.MkdirAll("tmp/net.d", 0755)
+	if err != nil {
+		Fail("Failed to create directory tmp/net.d")
+	}
+	err = os.MkdirAll("tmp/serviceaccount", 0755)
+	if err != nil {
+		Fail("Failed to create directory tmp/serviceaccount")
+	}
+	cleanup()
+
+	// Create a secrets file for parsing.
+	k8sSecret := []byte("my-secret-key")
+	err = ioutil.WriteFile(secretFile, k8sSecret, 0755)
+	if err != nil {
+		Fail(fmt.Sprintf("Failed to write k8s secret file: %v", err))
+	}
+})
+
+var _ = AfterSuite(func() {
+	err := os.RemoveAll("tmp")
+	if err != nil {
+		fmt.Println("Failed to clean up directories")
+	}
+})
+
+var _ = Describe("install-cni.sh tests", func() {
+	AfterEach(func() {
+		cleanup()
+	})
+
+	Describe("Run install-cni", func() {
+		Context("With default values", func() {
+			It("Should install bins and config", func() {
+				err := runCniContainer()
+				Expect(err).NotTo(HaveOccurred())
+
+				// Get a list of files in the defualt CNI bin location.
+				files, err := ioutil.ReadDir("tmp/bin")
+				if err != nil {
+					Fail("Could not list the files in tmp/bin")
+				}
+				names := []string{}
+				for _, file := range files {
+					names = append(names, file.Name())
+				}
+
+				// Get a list of files in the default location for CNI config.
+				files, err = ioutil.ReadDir("tmp/net.d")
+				if err != nil {
+					Fail("Could not list the files in tmp/net.d")
+				}
+				for _, file := range files {
+					names = append(names, file.Name())
+				}
+
+				Expect(names).To(ContainElement("calico"))
+				Expect(names).To(ContainElement("calico-ipam"))
+				Expect(names).To(ContainElement("10-calico.conf"))
+			})
+			It("Should parse and output a templated config", func() {
+				err := runCniContainer()
+				Expect(err).NotTo(HaveOccurred())
+
+				expectedFile := "expected_10-calico.conf"
+
+				var expected = []byte{}
+				if file, err := os.Open(expectedFile); err != nil {
+					Fail("Could not open " + expectedFile + " for reading")
+				} else {
+					_, err := file.Read(expected)
+					if err != nil {
+						Fail("Could not read from expected_10-calico.conf")
+					}
+					err = file.Close()
+					if err != nil {
+						fmt.Println("Failed to close expected_10-calico.conf")
+					}
+				}
+
+				var received = []byte{}
+				if file, err := os.Open("tmp/net.d/10-calico.conf"); err != nil {
+					Fail("Could not open 10-calico.conf for reading")
+				} else {
+					_, err := file.Read(received)
+					if err != nil {
+						Fail("Could not read from 10-calico.conf")
+					}
+					err = file.Close()
+					if err != nil {
+						fmt.Println("Failed to close 10-calico.conf")
+					}
+				}
+
+				Expect(expected).To(Equal(received))
+			})
+		})
+
+		Context("With modified env vars", func() {
+			It("Should rename '10-calico.conf' to '10-calico.conflist'", func() {
+				err := runCniContainer("-e", "CNI_CONF_NAME=10-calico.conflist")
+				Expect(err).NotTo(HaveOccurred())
+
+				expectedFile := "expected_10-calico.conf"
+
+				var expected = []byte{}
+				if file, err := os.Open(expectedFile); err != nil {
+					Fail("Could not open " + expectedFile + " for reading")
+				} else {
+					_, err := file.Read(expected)
+					if err != nil {
+						Fail("Could not read from expected_10-calico.conf")
+					}
+					err = file.Close()
+					if err != nil {
+						fmt.Println("Failed to close expected_10-calico.conf")
+					}
+				}
+
+				var received = []byte{}
+				if file, err := os.Open("tmp/net.d/10-calico.conflist"); err != nil {
+					Fail("Could not open 10-calico.conflist for reading")
+				} else {
+					_, err := file.Read(received)
+					if err != nil {
+						Fail("Could not read from 10-calico.conflist")
+					}
+					err = file.Close()
+					if err != nil {
+						fmt.Println("Failed to close 10-calico.conflist")
+					}
+				}
+
+				Expect(expected).To(Equal(received))
+			})
+		})
+	})
+})

--- a/k8s-install/scripts/scripts_suite_test.go
+++ b/k8s-install/scripts/scripts_suite_test.go
@@ -1,0 +1,13 @@
+package scripts_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestScripts(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Scripts Suite")
+}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Fixes #374 
Fixes #376 
I've added several tests to ensure at least basic functionality of the install-cni.sh script. I've also resolved a couple of minor bugs in the script for it not failing when it should.

I still have some minor concerns, I was unable to write a test to check that the script fails when we are unable to write the CNI bin files as we do not have `chattr` in the build container, and since we are running as root we have the capability to clobber anything otherwise, looking for suggestions here.

I am also unsure of this test:
https://github.com/projectcalico/cni-plugin/commit/5d1d18f2bd2ba1bdd0691c2e2cbd52f99b304eca#diff-2cac8d2716f994aa4216d877a9d2c84aR120
In the situation where both the primary and secondary bin dirs are not writable, it feels like we should fail, which is simple enough to fix but I'm unsure if this is set this way for a reason other than checking it exists.

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
