### PR TITLE
Set LabelsToApply on the CNI-created Profile

### DIFF
--- a/calico.go
+++ b/calico.go
@@ -313,8 +313,9 @@ func cmdAdd(args *skel.CmdArgs) error {
 					Labels: map[string]string{conf.Name: ""},
 				},
 				Spec: api.ProfileSpec{
-					EgressRules:  []api.Rule{{Action: "allow"}},
-					IngressRules: inboundRules,
+					EgressRules:   []api.Rule{{Action: "allow"}},
+					IngressRules:  inboundRules,
+					LabelsToApply: map[string]string{conf.Name: ""},
 				},
 			}
 


### PR DESCRIPTION
## Description
I believe the intention with the CNI plugin is that all workloads with the same conf.Name should have connectivity to each other, in the absence of any subsequent Policy.

In order to achieve that, the Profile needs to have LabelsToApply: {conf.Name: ""}, so that each WorkloadEndpoint inherits that label.