### PR TITLE
Fix that named ports weren't being copied across from the Pod spec.

### DIFF
--- a/calico_cni_k8s_test.go
+++ b/calico_cni_k8s_test.go
@@ -20,6 +20,7 @@ import (
 	client "github.com/projectcalico/libcalico-go/lib/clientv2"
 	"github.com/projectcalico/libcalico-go/lib/logutils"
 	"github.com/projectcalico/libcalico-go/lib/names"
+	"github.com/projectcalico/libcalico-go/lib/numorstring"
 	"github.com/projectcalico/libcalico-go/lib/options"
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
@@ -313,6 +314,11 @@ var _ = Describe("CalicoCni", func() {
 						Workload:      "",
 						ContainerID:   containerID,
 						Orchestrator:  "k8s",
+						Ports: []api.EndpointPort{{
+							Name:     "anamedport",
+							Protocol: numorstring.ProtocolFromString("tcp"),
+							Port:     555,
+						}},
 					}))
 
 					_, err = testutils.DeleteContainer(netconf, contNs.Path(), name, testutils.K8S_TEST_NS)

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -242,6 +242,7 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 		endpoint.Spec.Node = epIDs.Node
 		endpoint.Spec.Orchestrator = epIDs.Orchestrator
 		endpoint.Spec.Pod = epIDs.Pod
+		endpoint.Spec.Ports = ports
 
 		// Set the profileID according to whether Kubernetes policy is required.
 		// If it's not, then just use the network name (which is the normal behavior)


### PR DESCRIPTION
## Description
Fix that named ports weren't being copied across after merge of v2 datamodel.

Looks like it just got lost in the merge.

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
