### PR TITLE
Pin calico/build to v0.9 to pick up go 1.9.2 and CVE fixes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ CNI_SPEC_VERSION?=0.3.1
 
 # Ensure that the dist directory is always created
 MAKE_SURE_DIST_EXIST := $(shell mkdir -p dist)
-CALICO_BUILD?=calico/go-build
+CALICO_BUILD?=calico/go-build:v0.9
 DEPLOY_CONTAINER_NAME=calico/cni
 DEPLOY_CONTAINER_MARKER=cni_deploy_container.created
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Pin the calico/go-build container to v0.9 to pick up go 1.9.2 and CVE fixes.

I _do_ think we should pin to particular releases of go-build to ensure build consistency and repeatability of older builds.  `calico/go-build` isn't a synonym for `calico/go-build:latest` either, this has tripped up a few people before.

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
