### PR TITLE
Added CNI test args to allow cni to set WEP namespace from command line.

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -85,6 +85,12 @@ type NetConf struct {
 	EtcdCaCertFile string     `json:"etcd_ca_cert_file"`
 }
 
+// CNITestArgs is the CNI_ARGS used for test purpose.
+type CNITestArgs struct {
+	types.CommonArgs
+	CNI_TEST_NAMESPACE types.UnmarshallableString
+}
+
 // K8sArgs is the valid CNI_ARGS used for Kubernetes
 type K8sArgs struct {
 	types.CommonArgs

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -240,6 +240,15 @@ func GetIdentifiers(args *skel.CmdArgs, nodename string) (*WEPIdentifiers, error
 		epIDs.Pod = ""
 		// For any non-k8s orchestrator we set the namespace to default.
 		epIDs.Namespace = "default"
+
+		// Warning: CNITestArgs is used for test purpose only and subject to change without prior notice.
+		CNITestArgs := types.CNITestArgs{}
+		if err := cnitypes.LoadArgs(args.Args, &CNITestArgs); err == nil {
+			// Set namespace with the value passed by CNI test args.
+			if string(CNITestArgs.CNI_TEST_NAMESPACE) != "" {
+				epIDs.Namespace = string(CNITestArgs.CNI_TEST_NAMESPACE)
+			}
+		}
 	}
 
 	return &epIDs, nil


### PR DESCRIPTION
Added CNI test args to allow cni to set WEP namespace from command line. This is useful to have multiple namespaces for non k8s cluster. Currently it is used for test purpose only and subject to change without prior notice.


