### PR TITLE
v1.x: Do not clean up IPAM allocations if endpoint already existed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ addstats
 delstats
 *.pyc
 *.created
+*.test
 tmp-cni

--- a/calico.go
+++ b/calico.go
@@ -132,8 +132,18 @@ func cmdAdd(args *skel.CmdArgs) error {
 			// Don't create the veth or do any networking.
 			// Just update the profile on the endpoint. The profile will be created if needed during the
 			// profile processing step.
-			fmt.Fprintf(os.Stderr, "Calico CNI appending profile: %s\n", profileID)
-			endpoint.Spec.Profiles = append(endpoint.Spec.Profiles, profileID)
+			foundProfile := false
+			for _, p := range endpoint.Spec.Profiles {
+				if p == profileID {
+					fmt.Fprintf(os.Stderr, "Calico CNI endpoint already has profile: %s\n", profileID)
+					foundProfile = true
+					break
+				}
+			}
+			if !foundProfile {
+				fmt.Fprintf(os.Stderr, "Calico CNI appending profile: %s\n", profileID)
+				endpoint.Spec.Profiles = append(endpoint.Spec.Profiles, profileID)
+			}
 			result, err = CreateResultFromEndpoint(endpoint)
 			logger.WithField("result", result).Debug("Created result from endpoint")
 			if err != nil {

--- a/calico_cni_k8s_test.go
+++ b/calico_cni_k8s_test.go
@@ -7,8 +7,11 @@ import (
 	"os"
 	"syscall"
 	"time"
+	"os/exec"
+	"strings"
 
 	"github.com/containernetworking/cni/pkg/ns"
+	"github.com/containernetworking/cni/pkg/types/current"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
@@ -61,11 +64,11 @@ var _ = Describe("CalicoCni", func() {
 			    "type": "host-local",
 			    "subnet": "10.0.0.0/8"
 			  },
-				"kubernetes": {
-				  "k8s_api_root": "http://127.0.0.1:8080"
-				},
-				"policy": {"type": "k8s"},
-				"log_level":"info"
+			  "kubernetes": {
+			    "k8s_api_root": "http://127.0.0.1:8080"
+			  },
+			  "policy": {"type": "k8s"},
+			  "log_level":"info"
 			}`, cniVersion, os.Getenv("ETCD_IP"))
 
 			It("successfully networks the namespace", func() {
@@ -118,7 +121,7 @@ var _ = Describe("CalicoCni", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(endpoints.Items).Should(HaveLen(1))
 
-				// Set the Revision to nil since we can't assert it's exact value.
+				// Set the Revision to nil since we can't assert its exact value.
 				endpoints.Items[0].Metadata.Revision = nil
 				Expect(endpoints.Items[0].Metadata).Should(Equal(api.WorkloadEndpointMetadata{
 					Node:             hostname,
@@ -136,7 +139,7 @@ var _ = Describe("CalicoCni", func() {
 				}))
 
 				// Routes and interface on host - there's is nothing to assert on the routes since felix adds those.
-				//fmt.Println(Cmd("ip link show")) // Useful for debugging
+				// fmt.Println(Cmd("ip link show")) // Useful for debugging
 				hostVeth, err := netlink.LinkByName(interfaceName)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(hostVeth.Attrs().Flags.String()).Should(ContainSubstring("up"))
@@ -167,13 +170,14 @@ var _ = Describe("CalicoCni", func() {
 
 				// Assume the first IP is the IPv4 address
 				Expect(contAddresses[0].IP.String()).Should(Equal(ip))
-				Expect(contRoutes).Should(SatisfyAll(ContainElement(netlink.Route{
-					LinkIndex: contVeth.Attrs().Index,
-					Gw:        net.IPv4(169, 254, 1, 1).To4(),
-					Protocol:  syscall.RTPROT_BOOT,
-					Table:     syscall.RT_TABLE_MAIN,
-					Type:      syscall.RTN_UNICAST,
-				}),
+				Expect(contRoutes).Should(SatisfyAll(
+					ContainElement(netlink.Route{
+						LinkIndex: contVeth.Attrs().Index,
+						Gw:        net.IPv4(169, 254, 1, 1).To4(),
+						Protocol:  syscall.RTPROT_BOOT,
+						Table:     syscall.RT_TABLE_MAIN,
+						Type:      syscall.RTN_UNICAST,
+					}),
 					ContainElement(netlink.Route{
 						LinkIndex: contVeth.Attrs().Index,
 						Scope:     netlink.SCOPE_LINK,
@@ -938,24 +942,43 @@ var _ = Describe("CalicoCni", func() {
 				})
 			})
 
-			Context("Create a container then send another ADD for the same container", func() {
-				netconf := fmt.Sprintf(`
-				{
-				"cniVersion": "%s",
-				"name": "net8",
-				"type": "calico",
-				"etcd_endpoints": "http://%s:2379",
-			 	"ipam": {
-			    		"type": "calico-ipam"
-			        	},
-				"kubernetes": {
-					  "k8s_api_root": "http://127.0.0.1:8080"
-					 },
-				"policy": {"type": "k8s"},
-				"log_level":"info"
-				}`, cniVersion, os.Getenv("ETCD_IP"))
+			Context("after creating a pod", func() {
+				var netconf string
+				var workloadName, containerID, name string
+				var endpointSpec api.WorkloadEndpointSpec
+				var contNs ns.NetNS
+				var result *current.Result
 
-				It("should successfully execute both ADDs but for second ADD will return the same result as the first time but it won't network the container", func() {
+				checkIPAMReservation := func() {
+					// IPAM reservation should still be in place.
+					ipamIPs, err := calicoClient.IPAM().IPsByHandle(workloadName)
+					ExpectWithOffset(0, err).NotTo(HaveOccurred())
+					ExpectWithOffset(0, ipamIPs).To(HaveLen(1),
+						"There should be an IPAM handle for endpoint")
+					ExpectWithOffset(0, ipamIPs[0].To16()).To(ConsistOf(endpointSpec.IPNetworks[0].IP.To16()))
+				}
+
+				BeforeEach(func() {
+					netconf = fmt.Sprintf(
+						`
+							{
+							"cniVersion": "%s",
+							"name": "net8",
+							"type": "calico",
+							"etcd_endpoints": "http://%s:2379",
+							"ipam": {
+									"type": "calico-ipam"
+									},
+							"kubernetes": {
+								  "k8s_api_root": "http://127.0.0.1:8080"
+								 },
+							"policy": {"type": "k8s"},
+							"log_level":"info"
+							}`,
+						cniVersion,
+						os.Getenv("ETCD_IP"),
+					)
+
 					// Create a new ipPool.
 					c, _ := client.NewFromEnv()
 					testutils.CreateNewIPPool(*c, "10.0.0.0/24", false, false, true)
@@ -967,7 +990,7 @@ var _ = Describe("CalicoCni", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					// Now create a K8s pod.
-					name := fmt.Sprintf("run%d-pool", rand.Uint32())
+					name = fmt.Sprintf("run%d-pool", rand.Uint32())
 
 					pod, err := clientset.Pods(K8S_TEST_NS).Create(
 						&v1.Pod{
@@ -983,12 +1006,12 @@ var _ = Describe("CalicoCni", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					log.Infof("Created POD object: %v", pod)
-
-					containerID, session, _, _, _, contNs, err := CreateContainer(netconf, name, "")
+					var session *gexec.Session
+					containerID, session, _, _, _, contNs, err = CreateContainer(netconf, name, "")
 					Expect(err).ShouldNot(HaveOccurred())
-					Eventually(session).Should(gexec.Exit())
+					Eventually(session).Should(gexec.Exit(0))
 
-					result, err := GetResultForCurrent(session, cniVersion)
+					result, err = GetResultForCurrent(session, cniVersion)
 					if err != nil {
 						log.Fatalf("Error getting result from the session: %v\n", err)
 					}
@@ -1001,31 +1024,68 @@ var _ = Describe("CalicoCni", func() {
 					Expect(endpoints.Items).Should(HaveLen(1))
 
 					// Set the Revision to nil since we can't assert it's exact value.
-					endpoints.Items[0].Metadata.Revision = nil
-					Expect(endpoints.Items[0].Metadata).Should(Equal(api.WorkloadEndpointMetadata{
+					endpoint := endpoints.Items[0]
+					endpoint.Metadata.Revision = nil
+					workloadName = fmt.Sprintf("test.%s", name)
+					Expect(endpoint.Metadata).Should(Equal(api.WorkloadEndpointMetadata{
 						Node:             hostname,
 						Name:             "eth0",
-						Workload:         fmt.Sprintf("test.%s", name),
+						Workload:         workloadName,
 						ActiveInstanceID: containerID,
 						Orchestrator:     "k8s",
 						Labels:           map[string]string{"calico/k8s_ns": "test"},
 					}))
+					endpointSpec = endpoint.Spec
+					Expect(endpointSpec.IPNetworks).To(HaveLen(1))
 
+					checkIPAMReservation()
+				})
+
+				It("a second ADD for the same container should be a no-op", func() {
 					// Try to create the same container (so CNI receives the ADD for the same endpoint again)
-					session, _, _, _, err = RunCNIPluginWithId(netconf, name, "", containerID, contNs)
-					Expect(err).ShouldNot(HaveOccurred())
-					Eventually(session).Should(gexec.Exit())
+					session, _, _, _, err := RunCNIPluginWithId(netconf, name, "", containerID, contNs)
+					Expect(err).NotTo(HaveOccurred())
+					Eventually(session).Should(gexec.Exit(0))
 
 					resultSecondAdd, err := GetResultForCurrent(session, cniVersion)
-					if err != nil {
-						log.Fatalf("Error getting result from the session: %v\n", err)
-					}
+					Expect(err).NotTo(HaveOccurred())
 
 					log.Printf("Unmarshalled result from second ADD: %v\n", resultSecondAdd)
 					Expect(resultSecondAdd).Should(Equal(result))
 
+					// IPAM reservation should still be in place.
+					checkIPAMReservation()
+
 					_, err = DeleteContainer(netconf, contNs.Path(), "")
 					Expect(err).ShouldNot(HaveOccurred())
+				})
+
+				Context("with networking rigged to fail", func() {
+					BeforeEach(func() {
+						// To prevent the networking atempt from succeeding, rename the old veth.
+						// This leaves a route and an eth0 in place that the plugin will struggle with.
+						hostVeth := endpointSpec.InterfaceName
+						newName := strings.Replace(hostVeth, "cali", "sali", 1)
+						output, err := exec.Command("ip", "link", "set", hostVeth, "down").CombinedOutput()
+						Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Output: %s", output))
+						output, err = exec.Command("ip", "link", "set", hostVeth, "name", newName).CombinedOutput()
+						Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Output: %s", output))
+						output, err = exec.Command("ip", "link", "set", newName, "up").CombinedOutput()
+						Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Output: %s", output))
+					})
+
+					It("a second ADD should leave the datastore untouched", func() {
+						// Try to create the same container (so CNI receives the ADD for the same endpoint again)
+						session, _, _, _, err := RunCNIPluginWithId(netconf, name, "", containerID, contNs)
+						Expect(err).ShouldNot(HaveOccurred())
+						Eventually(session).Should(gexec.Exit(1))
+
+						// IPAM reservation should still be in place.
+						checkIPAMReservation()
+
+						_, err = DeleteContainer(netconf, contNs.Path(), "")
+						Expect(err).ShouldNot(HaveOccurred())
+					})
 				})
 			})
 

--- a/utils/network.go
+++ b/utils/network.go
@@ -232,9 +232,11 @@ func setupRoutes(hostVeth netlink.Link, result *current.Result) error {
 						return nil
 					}
 				}
-				return fmt.Errorf("route (Dst: %s, Scope: %s) already exists for an interface other than '%s'", route.Dst.String(), route.Scope, hostVeth.Attrs().Name)
+				return fmt.Errorf("route (Dst: %s, Scope: %v) already exists for an interface other than '%s'",
+					route.Dst.String(), route.Scope, hostVeth.Attrs().Name)
 			default:
-				return fmt.Errorf("failed to add route (Dst: %s, Scope: %s, Iface: %s): %v", route.Dst.String(), route.Scope, hostVeth.Attrs().Name, err)
+				return fmt.Errorf("failed to add route (Dst: %s, Scope: %v, Iface: %s): %v",
+					route.Dst.String(), route.Scope, hostVeth.Attrs().Name, err)
 			}
 		}
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Prevents us from releasing an IP that is still attached to the endpoint.

Fixes one of the problems identified under #1253

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that, if the CNI plugin failed to re-network an existing endpoint, it would release the IP allocation to the pool even though it was still attached to the endpoint.
```
