### PR TITLE
Adding ability to define a floating ip for a kubernetes workload via annotation

### DIFF
--- a/calico_cni_k8s_test.go
+++ b/calico_cni_k8s_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/options"
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -464,6 +464,81 @@ var _ = Describe("CalicoCni", func() {
 					log.Infof("All container IPs: %v", contAddresses)
 					log.Infof("Container got IP address: %s", podIP)
 					Expect(ipPoolCIDR.Contains(podIP)).To(BeTrue())
+
+					// Delete the container.
+					_, err = testutils.DeleteContainer(netconfCalicoIPAM, contNs.Path(), name, testutils.K8S_TEST_NS)
+					Expect(err).ShouldNot(HaveOccurred())
+				})
+			})
+
+			Context("using floatingIPs annotation to assign a DNAT", func() {
+				It("successfully assigns a DNAT IP address from the annotated floatingIP", func() {
+					netconfCalicoIPAM := fmt.Sprintf(`
+					{
+					  "cniVersion": "%s",
+					  "name": "net11",
+					  "type": "calico",
+					  "etcd_endpoints": "http://%s:2379",
+			          	  "nodename_file_optional": true,
+					  "datastore_type": "%s",
+					  "ipam": {
+					    "type": "calico-ipam"
+					  },
+					  "kubernetes": {
+					    "k8s_api_root": "http://127.0.0.1:8080"
+					   },
+					  "policy": {"type": "k8s"},
+					  "log_level":"info"
+					}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"))
+
+					// Create a new ipPool.
+					for _, ipPool := range []string{"172.16.0.0/16", "1.1.1.0/24"} {
+						testutils.MustCreateNewIPPool(calicoClient, ipPool, false, false, true)
+						_, _, err := net.ParseCIDR(ipPool)
+						Expect(err).NotTo(HaveOccurred())
+					}
+
+					config, err := clientcmd.DefaultClientConfig.ClientConfig()
+					Expect(err).NotTo(HaveOccurred())
+
+					clientset, err := kubernetes.NewForConfig(config)
+					Expect(err).NotTo(HaveOccurred())
+
+					// Now create a K8s pod passing in a floating IP.
+					ensureNamespace(clientset, testutils.K8S_TEST_NS)
+					name := fmt.Sprintf("run%d", rand.Uint32())
+					pod, err := clientset.CoreV1().Pods(testutils.K8S_TEST_NS).Create(&v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: name,
+							Annotations: map[string]string{
+								"cni.projectcalico.org/floatingIPs": "[\"1.1.1.1\"]",
+							},
+						},
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{{
+								Name:  name,
+								Image: "ignore",
+							}},
+							NodeName: hostname,
+						},
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					log.Infof("Created POD object: %v", pod)
+
+					_, _, _, contAddresses, _, contNs, err := testutils.CreateContainer(netconfCalicoIPAM, name, testutils.K8S_TEST_NS, "")
+					Expect(err).NotTo(HaveOccurred())
+
+					podIP := contAddresses[0].IP
+
+					// Assert that the endpoint is created
+					endpoints, err := calicoClient.WorkloadEndpoints().List(ctx, options.ListOptions{})
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(endpoints.Items).Should(HaveLen(1))
+
+					// Assert that the endpoint contains the appropriate DNAT
+					Expect(endpoints.Items[0].Spec.IPNATs).Should(HaveLen(1))
+					Expect(endpoints.Items[0].Spec.IPNATs).Should(Equal([]api.IPNAT{api.IPNAT{InternalIP: podIP.String(), ExternalIP: "1.1.1.1"}}))
 
 					// Delete the container.
 					_, err = testutils.DeleteContainer(netconfCalicoIPAM, contNs.Path(), name, testutils.K8S_TEST_NS)

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -362,6 +362,23 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 	endpoint.Spec.InterfaceName = hostVethName
 	endpoint.Spec.ContainerID = epIDs.ContainerID
 	logger.WithField("endpoint", endpoint).Info("Added Mac, interface name, and active container ID to endpoint")
+	// List of DNAT ipaddrs to map to this workload endpoint
+	floatingIPs := annot["cni.projectcalico.org/floatingIPs"]
+
+	if floatingIPs != "" {
+		ips, err := parseIPAddrs(floatingIPs, logger)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, ip := range ips {
+			endpoint.Spec.IPNATs = append(endpoint.Spec.IPNATs, api.IPNAT{
+				InternalIP: result.IPs[0].Address.IP.String(),
+				ExternalIP: ip,
+			})
+		}
+		logger.WithField("endpoint", endpoint).Info("Added floatingIPs to endpoint")
+	}
 
 	// Write the endpoint object (either the newly created one, or the updated one)
 	if _, err := utils.CreateOrUpdate(ctx, calicoClient, endpoint); err != nil {


### PR DESCRIPTION
## Description
This PR adds the ability to define DNAT/floating IP for a kubernetes workload via annotation. Most of the plumbing was already in place, this adds the missing link. 

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
```release-note
You can now define a floating IP ( DNAT ) via container annotation `cni.projectcalico.org/floatingIPs`
```
