### PR TITLE
Copy File Error, Please check whether disabled selinux on your host

### DIFF
--- a/k8s-install/scripts/install-cni.sh
+++ b/k8s-install/scripts/install-cni.sh
@@ -77,6 +77,11 @@ do
 			continue
 		fi
 		cp $path $dir/
+		if [ "$?" != "0" ];
+		then
+			echo "Failed to copy $path to $dir. This may be caused by selinux configuration on the host, or something else."
+			exit 1
+		fi
 	done
 
 	echo "Wrote Calico CNI binaries to $dir"
@@ -143,6 +148,11 @@ if [ "${CNI_CONF_NAME}" != "${CNI_OLD_CONF_NAME}" ]; then
 fi
 # Move the temporary CNI config into place.
 mv $TMP_CONF /host/etc/cni/net.d/${CNI_CONF_NAME}
+if [ "$?" != "0" ];
+then
+	echo "Failed to mv files. This may be caused by selinux configuration on the host, or something else."
+	exit 1
+fi
 
 echo "Created CNI config ${CNI_CONF_NAME}"
 


### PR DESCRIPTION
Signed-off-by: zhangjie <zhangjie0619@yeah.net>

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

we can not write file in container source volume when  host selinux is not disable .
so if we did not disable selinux, when cni_install container started, i will occurred following errors:

```

Wrote Calico CNI binaries to /host/opt/cni/bin
CNI plugin version: 
/host/secondary-bin-dir is non-writeable, skipping
cp: can't create '/host/opt/cni/bin/calico': Permission denied
cp: can't create '/host/opt/cni/bin/calico-ipam': Permission denied
cp: can't create '/host/opt/cni/bin/flannel': File exists
cp: can't create '/host/opt/cni/bin/host-local': File exists
cp: can't create '/host/opt/cni/bin/loopback': File exists
cp: can't create '/host/opt/cni/bin/portmap': Permission denied
/install-cni.sh: line 83: /host/opt/cni/bin/calico: not found
         "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
         "k8s_api_root": "https://10.96.0.1:__KUBERNETES_SERVICE_PORT__",
CNI config: {
    "name": "k8s-pod-network",
    "cniVersion": "0.1.0",
    "type": "calico",
    "etcd_endpoints": "http://10.*.*.136:6666",
    "log_level": "info",
    "mtu": 1500,
    "ipam": {
        "type": "calico-ipam"
    },
    "policy": {
        "type": "k8s",
         "k8s_api_root": "https://10.*.0.1:443",
         "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
    },
    "kubernetes": {
        "kubeconfig": "/etc/cni/net.d/calico-kubeconfig"
    }
}
Created CNI config 10-calico.conf
Done configuring CNI.  Sleep=true
/install-cni.sh: line 98: can't create /host/etc/cni/net.d/calico-kubeconfig: Permission denied
mv: can't create '/host/etc/cni/net.d/10-calico.conf': Permission denied

```

this pr will give some tips when copy file error.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note

```
