### PR TITLE
Revert to old behavior of calculating veth name from pod name

### DIFF
--- a/calico_cni_k8s_test.go
+++ b/calico_cni_k8s_test.go
@@ -131,7 +131,7 @@ var _ = Describe("CalicoCni", func() {
 				wrkload, err := ids.CalculateWorkloadEndpointName(false)
 				Expect(err).NotTo(HaveOccurred())
 
-				interfaceName := k8sconversion.VethNameForWorkload(testutils.K8S_TEST_NS, wrkload)
+				interfaceName := k8sconversion.VethNameForWorkload(testutils.K8S_TEST_NS, name)
 
 				// The endpoint is created
 				endpoints, err := calicoClient.WorkloadEndpoints().List(ctx, options.ListOptions{})
@@ -289,7 +289,7 @@ var _ = Describe("CalicoCni", func() {
 					}
 
 					wrkload, err := ids.CalculateWorkloadEndpointName(false)
-					interfaceName := k8sconversion.VethNameForWorkload(testutils.K8S_TEST_NS, wrkload)
+					interfaceName := k8sconversion.VethNameForWorkload(testutils.K8S_TEST_NS, name)
 					Expect(err).NotTo(HaveOccurred())
 
 					// The endpoint is created
@@ -513,7 +513,7 @@ var _ = Describe("CalicoCni", func() {
 					wrkload, err := ids.CalculateWorkloadEndpointName(false)
 					Expect(err).NotTo(HaveOccurred())
 
-					interfaceName := k8sconversion.VethNameForWorkload(testutils.K8S_TEST_NS, wrkload)
+					interfaceName := k8sconversion.VethNameForWorkload(testutils.K8S_TEST_NS, name)
 
 					// The endpoint is created
 					endpoints, err := calicoClient.WorkloadEndpoints().List(ctx, options.ListOptions{})
@@ -623,7 +623,7 @@ var _ = Describe("CalicoCni", func() {
 					wrkload, err := ids.CalculateWorkloadEndpointName(false)
 					Expect(err).NotTo(HaveOccurred())
 
-					interfaceName := k8sconversion.VethNameForWorkload(testutils.K8S_TEST_NS, wrkload)
+					interfaceName := k8sconversion.VethNameForWorkload(testutils.K8S_TEST_NS, name)
 
 					// Make sure WorkloadEndpoint is created and has the requested IP in the datastore.
 					endpoints, err := calicoClient.WorkloadEndpoints().List(ctx, options.ListOptions{})
@@ -731,7 +731,7 @@ var _ = Describe("CalicoCni", func() {
 					wrkload, err := ids.CalculateWorkloadEndpointName(false)
 					Expect(err).NotTo(HaveOccurred())
 
-					interfaceName := k8sconversion.VethNameForWorkload(testutils.K8S_TEST_NS, wrkload)
+					interfaceName := k8sconversion.VethNameForWorkload(testutils.K8S_TEST_NS, name)
 
 					// Make sure WorkloadEndpoint is created and has the requested IP in the datastore.
 					endpoints, err := calicoClient.WorkloadEndpoints().List(ctx, options.ListOptions{})

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 710410e8a99fb29d4d91b0d6afd94797fdc7b679300cc84330bf3c1592c1ca9c
-updated: 2017-11-10T21:51:23.438037-08:00
+hash: edc2ad9e4e4d40159a881b548f12ce4b03ed3adf6b47eb39a9c2b4c7068b7660
+updated: 2017-11-14T11:54:52.438468-08:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -186,7 +186,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: a21bd104b2d077c89737a5b897e3ac817c79957a
+  version: 250cb94738bf94032f2af491e362543f346cfac9
   subpackages:
   - lib/apiconfig
   - lib/apis/v2
@@ -226,13 +226,13 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 49fee292b27bfff7f354ee0f64e1bc4850462edf
+  version: e3fb1a1acd7605367a2b378bc2e2f893c05174b7
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: a1dba9ce8baed984a2495b658c82687f8157b98f
+  version: a6e9df898b1336106c743392c48ee0b71f5c4efa
   subpackages:
   - xfs
 - name: github.com/PuerkitoBio/purell

--- a/glide.yaml
+++ b/glide.yaml
@@ -18,7 +18,7 @@ import:
   subpackages:
   - gexec
 - package: github.com/projectcalico/libcalico-go
-  version: a21bd104b2d077c89737a5b897e3ac817c79957a
+  version: 250cb94738bf94032f2af491e362543f346cfac9
   subpackages:
   - lib/apiconfig
   - lib/apis/v2

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -269,7 +269,7 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 	fmt.Fprintf(os.Stderr, "Calico CNI using IPs: %s\n", endpoint.Spec.IPNetworks)
 
 	// Whether the endpoint existed or not, the veth needs (re)creating.
-	hostVethName := k8sconversion.VethNameForWorkload(epIDs.Namespace, epIDs.WEPName)
+	hostVethName := k8sconversion.VethNameForWorkload(epIDs.Namespace, epIDs.Pod)
 	_, contVethMac, err := utils.DoNetworking(args, conf, result, logger, hostVethName)
 	if err != nil {
 		// Cleanup IP allocation and return the error.


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Revert to the Calico 2.x veth name construction algorithm.

```release-note
None required
```
