### PR TITLE
v3: Fix ipam inconsistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ addstats
 delstats
 *.pyc
 *.created
+*.test
 tmp-cni
 k8s-install/scripts/tmp/
 install_cni.test

--- a/ipam/calico-ipam.go
+++ b/ipam/calico-ipam.go
@@ -168,6 +168,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 			return err
 		}
 
+		fmt.Fprintf(os.Stderr, "Calico CNI IPAM handle=%s\n", epIDs.WEPName)
 		assignArgs := ipam.AutoAssignArgs{
 			Num4:      num4,
 			Num6:      num6,

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -58,7 +58,8 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 
 	logger.Info("Extracted identifiers for CmdAddK8s")
 
-	if endpoint != nil && len(endpoint.Spec.IPNetworks) != 0 {
+	endpointAlreadyExisted := endpoint != nil && len(endpoint.Spec.IPNetworks) != 0
+	if endpointAlreadyExisted {
 		// This happens when Docker or the node restarts. K8s calls CNI with the same parameters as before.
 		// Do the networking (since the network namespace was destroyed and recreated).
 		// There's an existing endpoint - no need to create another. Find the IP address from the endpoint
@@ -268,21 +269,32 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 	}
 	fmt.Fprintf(os.Stderr, "Calico CNI using IPs: %s\n", endpoint.Spec.IPNetworks)
 
+	// maybeReleaseIPAM cleans up any IPAM allocations if we were creating a new endpoint;
+	// it is a no-op if this was a re-network of an existing endpoint.
+	maybeReleaseIPAM := func() {
+		logger.Debug("Checking if we need to clean up IPAM.")
+		logger := logger.WithField("IPs", endpoint.Spec.IPNetworks)
+		if endpointAlreadyExisted {
+			logger.Info("Not cleaning up IPAM allocation; this was a pre-existing endpoint.")
+			return
+		}
+		logger.Info("Releasing IPAM allocation after failure")
+		utils.ReleaseIPAllocation(logger, conf.IPAM.Type, args.StdinData)
+	}
+
 	// Whether the endpoint existed or not, the veth needs (re)creating.
 	hostVethName := k8sconversion.VethNameForWorkload(epIDs.Namespace, epIDs.Pod)
 	_, contVethMac, err := utils.DoNetworking(args, conf, result, logger, hostVethName)
 	if err != nil {
-		// Cleanup IP allocation and return the error.
-		logger.Errorf("Error setting up networking: %s", err)
-		utils.ReleaseIPAllocation(logger, conf.IPAM.Type, args.StdinData)
+		logger.WithError(err).Error("Error setting up networking")
+		maybeReleaseIPAM()
 		return nil, err
 	}
 
 	mac, err := net.ParseMAC(contVethMac)
 	if err != nil {
-		// Cleanup IP allocation and return the error.
-		logger.Errorf("Error parsing MAC (%s): %s", contVethMac, err)
-		utils.ReleaseIPAllocation(logger, conf.IPAM.Type, args.StdinData)
+		logger.WithError(err).WithField("mac", mac).Error("Error parsing container MAC")
+		maybeReleaseIPAM()
 		return nil, err
 	}
 	endpoint.Spec.MAC = mac.String()
@@ -292,8 +304,8 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 
 	// Write the endpoint object (either the newly created one, or the updated one)
 	if _, err := utils.CreateOrUpdate(ctx, calicoClient, endpoint); err != nil {
-		// Cleanup IP allocation and return the error.
-		utils.ReleaseIPAllocation(logger, conf.IPAM.Type, args.StdinData)
+		logger.WithError(err).Error("Error creating/updating endpoint in datastore.")
+		maybeReleaseIPAM()
 		return nil, err
 	}
 	logger.Info("Wrote updated endpoint to datastore")

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -256,7 +256,21 @@ func CreateContainerWithId(netconf, podName, podNamespace, ip, containerId strin
 
 // RunCNIPluginWithId calls CNI plugin with a containerID and targetNs passed to it.
 // This is for when you want to call CNI for an existing container.
-func RunCNIPluginWithId(netconf, podName, podNamespace, ip, containerId, ifName string, targetNs ns.NetNS) (session *gexec.Session, contVeth netlink.Link, contAddr []netlink.Addr, contRoutes []netlink.Route, err error) {
+func RunCNIPluginWithId(
+	netconf,
+	podName,
+	podNamespace,
+	ip,
+	containerId,
+	ifName string,
+	targetNs ns.NetNS,
+) (
+	session *gexec.Session,
+	contVeth netlink.Link,
+	contAddr []netlink.Addr,
+	contRoutes []netlink.Route,
+	err error,
+) {
 
 	// Set up the env for running the CNI plugin
 	k8sEnv := ""

--- a/utils/network.go
+++ b/utils/network.go
@@ -238,9 +238,11 @@ func setupRoutes(hostVeth netlink.Link, result *current.Result) error {
 						return nil
 					}
 				}
-				return fmt.Errorf("route (Dst: %s, Scope: %s) already exists for an interface other than '%s'", route.Dst.String(), route.Scope, hostVeth.Attrs().Name)
+				return fmt.Errorf("route (Dst: %s, Scope: %v) already exists for an interface other than '%s'",
+					route.Dst.String(), route.Scope, hostVeth.Attrs().Name)
 			default:
-				return fmt.Errorf("failed to add route (Dst: %s, Scope: %s, Iface: %s): %v", route.Dst.String(), route.Scope, hostVeth.Attrs().Name, err)
+				return fmt.Errorf("failed to add route (Dst: %s, Scope: %v, Iface: %s): %v",
+					route.Dst.String(), route.Scope, hostVeth.Attrs().Name, err)
 			}
 		}
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Prevents us from releasing an IP that is still attached to the endpoint.

Fixes one of the problems identified under https://github.com/projectcalico/calico/issues/1253
Forward-port of #418 to master.

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix that, if the CNI plugin failed to re-network an existing endpoint, it would release the IP allocation to the pool even though it was still attached to the endpoint.
```
