### PR TITLE
Set MAC on host side of veth pair

### DIFF
--- a/calico_cni_test.go
+++ b/calico_cni_test.go
@@ -75,8 +75,6 @@ var _ = Describe("CalicoCni", func() {
 					log.Fatalf("Error getting result from the session: %v\n", err)
 				}
 
-				mac := contVeth.Attrs().HardwareAddr
-
 				Expect(len(result.IPs)).Should(Equal(1))
 				ip := result.IPs[0].Address.IP.String()
 				result.IPs[0].Address.IP = result.IPs[0].Address.IP.To4() // Make sure the IP is respresented as 4 bytes
@@ -105,6 +103,8 @@ var _ = Describe("CalicoCni", func() {
 					Orchestrator:     "cni",
 				}))
 
+				mac := contVeth.Attrs().HardwareAddr
+
 				Expect(endpoints.Items[0].Spec).Should(Equal(api.WorkloadEndpointSpec{
 					InterfaceName: fmt.Sprintf("cali%s", containerID),
 					IPNetworks:    []cnet.IPNet{{result.IPs[0].Address}},
@@ -120,6 +120,7 @@ var _ = Describe("CalicoCni", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(hostVeth.Attrs().Flags.String()).Should(ContainSubstring("up"))
 				Expect(hostVeth.Attrs().MTU).Should(Equal(1500))
+				Expect(hostVeth.Attrs().HardwareAddr.String()).Should(Equal("ee:ee:ee:ee:ee:ee"))
 
 				// Assert hostVeth sysctl values are set to what we expect for IPv4.
 				err = CheckSysctlValue(fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/proxy_arp", hostVethName), "1")

--- a/utils/network.go
+++ b/utils/network.go
@@ -57,6 +57,16 @@ func DoNetworking(args *skel.CmdArgs, conf NetConf, result *current.Result, logg
 			return err
 		}
 
+		if mac, err := net.ParseMAC("EE:EE:EE:EE:EE:EE"); err != nil {
+			logger.Infof("failed to parse MAC Address: %v. Using kernel generated MAC.", err)
+		} else {
+			// Set the MAC address on the host side interface so the kernel does not
+			// have to generate a persistent address which fails some times.
+			if err = netlink.LinkSetHardwareAddr(hostVeth, mac); err != nil {
+				logger.Warnf("failed to Set MAC of %q: %v. Using kernel generated MAC.", hostVethName, err)
+			}
+		}
+
 		// Explicitly set the veth to UP state, because netlink doesn't always do that on all the platforms with net.FlagUp.
 		// veth won't get a link local address unless it's set to UP state.
 		if err = netlink.LinkSetUp(hostVeth); err != nil {


### PR DESCRIPTION
- Applied changes made on v2.0-beta (Calico v3.0-beta)
- Setting the MAC address avoids issues when kernel fails to generate a
  persistent MAC address