### PR TITLE
Pass the architecture to test containers.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,7 @@ test-containerized: run-etcd run-k8s-apiserver build-containerized $(DIST)/host-
 	docker run --rm --privileged --net=host \
 	-e ETCD_IP=$(LOCAL_IP_ENV) \
 	-e LOCAL_USER_ID=0 \
+	-e ARCH=$(ARCH) \
 	-e PLUGIN=calico \
 	-e DIST=$(DIST) \
 	-e CNI_SPEC_VERSION=$(CNI_SPEC_VERSION) \
@@ -190,6 +191,7 @@ run-test-containerized-without-building: run-etcd run-k8s-apiserver
 	docker run --rm --privileged --net=host \
 	-e ETCD_IP=$(LOCAL_IP_ENV) \
 	-e LOCAL_USER_ID=0 \
+	-e ARCH=$(ARCH) \
 	-e PLUGIN=calico \
 	-e DIST=$(DIST) \
 	-e CNI_SPEC_VERSION=$(CNI_SPEC_VERSION) \


### PR DESCRIPTION
Pass the ARCH environment variable to the test container
when running test-containerized targets.

Signed-off-by: David Wilder <wilder@us.ibm.com>

## Description
This fixes a recent test failures on ppc64le.


## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
