### PR TITLE
error out if Ready flag is not set (v1.11.x)

### DIFF
--- a/calico.go
+++ b/calico.go
@@ -92,6 +92,15 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return err
 	}
 
+	ready, err := IsReady(calicoClient)
+	if err != nil {
+		return err
+	}
+	if !ready {
+		logger.Warn("Upgrade may be in progress, ready flag is not set")
+		return fmt.Errorf("Calico is currently not ready to process requests")
+	}
+
 	// Always check if there's an existing endpoint.
 	endpoints, err := calicoClient.WorkloadEndpoints().List(api.WorkloadEndpointMetadata{
 		Node:         nodename,
@@ -331,6 +340,15 @@ func cmdDel(args *skel.CmdArgs) error {
 	calicoClient, err := CreateClient(conf)
 	if err != nil {
 		return err
+	}
+
+	ready, err := IsReady(calicoClient)
+	if err != nil {
+		return err
+	}
+	if !ready {
+		logger.Warn("Upgrade may be in progress, ready flag is not set")
+		return fmt.Errorf("Calico is currently not ready to process requests")
 	}
 
 	wep := api.WorkloadEndpointMetadata{

--- a/test_utils/utils.go
+++ b/test_utils/utils.go
@@ -26,6 +26,8 @@ import (
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega/gexec"
 	k8sbackend "github.com/projectcalico/libcalico-go/lib/backend/k8s"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
+	"github.com/projectcalico/libcalico-go/lib/client"
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 )
@@ -51,6 +53,20 @@ func min(a, b int) int {
 func WipeEtcd() {
 	_, err := kapi.Delete(context.Background(), "/calico", &etcdclient.DeleteOptions{Dir: true, Recursive: true})
 	if err != nil && !etcdclient.IsKeyNotFound(err) {
+		panic(err)
+	}
+
+	calicoClient, err := client.NewFromEnv()
+	if err != nil {
+		panic(err)
+	}
+	// Set the Ready flag so the CNI plugin can run
+	_, err = calicoClient.Backend.Apply(
+		&model.KVPair{
+			Key:   model.ReadyFlagKey{},
+			Value: true,
+		})
+	if err != nil {
 		panic(err)
 	}
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -32,6 +32,7 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/projectcalico/libcalico-go/lib/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/client"
 	cnet "github.com/projectcalico/libcalico-go/lib/net"
 	"github.com/vishvananda/netlink"
@@ -261,6 +262,21 @@ func CreateClient(conf NetConf) (*client.Client, error) {
 		return nil, err
 	}
 	return calicoClient, nil
+}
+
+// Check the Datastore for the ready flag to know if it is ok to proceed
+func IsReady(client *client.Client) (bool, error) {
+	kvPair, err := client.Backend.Get(model.ReadyFlagKey{})
+	if err != nil {
+		return false, fmt.Errorf("Unable to retreive ReadyFlag from Backend: %v", err)
+	}
+
+	v, ok := kvPair.Value.(bool)
+	if !ok {
+		return false, fmt.Errorf("Invalid data in Value for ReadyFlag")
+	}
+
+	return v, nil
 }
 
 // ReleaseIPAllocation is called to cleanup IPAM allocations if something goes wrong during


### PR DESCRIPTION
Here is a quick shot at checking the Ready flag before doing any operations.

Todo:
- Add some tests
- Maybe rework if we want to expose the ready flag through the Client interface instead of using a Get to the Backend

```release-note
None required
```
