### PR TITLE
Changing the handle we use for IPAM

### DIFF
--- a/calico_cni_k8s_test.go
+++ b/calico_cni_k8s_test.go
@@ -969,7 +969,8 @@ var _ = Describe("CalicoCni", func() {
 
 				checkIPAMReservation := func() {
 					// IPAM reservation should still be in place.
-					ipamIPs, err := calicoClient.IPAM().IPsByHandle(workloadName)
+					handleID, _ := utils.GetHandleID("net8", containerID, containerID)
+					ipamIPs, err := calicoClient.IPAM().IPsByHandle(handleID)
 					ExpectWithOffset(0, err).NotTo(HaveOccurred())
 					ExpectWithOffset(0, ipamIPs).To(HaveLen(1),
 						"There should be an IPAM handle for endpoint")

--- a/calico_cni_test.go
+++ b/calico_cni_test.go
@@ -383,7 +383,8 @@ var _ = Describe("CalicoCni", func() {
 
 		checkIPAMReservation := func() {
 			// IPAM reservation should still be in place.
-			ipamIPs, err := calicoClient.IPAM().IPsByHandle(containerID)
+			handleID, _ := utils.GetHandleID("net1", containerID, containerID)
+			ipamIPs, err := calicoClient.IPAM().IPsByHandle(handleID)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 			ExpectWithOffset(1, ipamIPs).To(HaveLen(1),
 				"There should be an IPAM handle for endpoint")

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -20,22 +20,22 @@ import (
 	"net"
 	"os"
 	"regexp"
+	"strings"
+
+	"github.com/containernetworking/cni/pkg/ns"
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/vishvananda/netlink"
 
 	log "github.com/sirupsen/logrus"
 
-	"strings"
-
 	"github.com/containernetworking/cni/pkg/ip"
 	"github.com/containernetworking/cni/pkg/ipam"
-	"github.com/containernetworking/cni/pkg/ns"
-	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
-	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/projectcalico/libcalico-go/lib/api"
 	"github.com/projectcalico/libcalico-go/lib/backend/model"
 	"github.com/projectcalico/libcalico-go/lib/client"
 	cnet "github.com/projectcalico/libcalico-go/lib/net"
-	"github.com/vishvananda/netlink"
 )
 
 func Min(a, b int) int {
@@ -169,6 +169,18 @@ func GetIdentifiers(args *skel.CmdArgs) (workloadID string, orchestratorID strin
 		orchestratorID = "cni"
 	}
 	return workloadID, orchestratorID, nil
+}
+
+func GetHandleID(netName string, containerID string, workload string) (string, error) {
+	handleID := fmt.Sprintf("%s.%s", netName, containerID)
+	log.WithFields(log.Fields{
+		"Network":     netName,
+		"ContainerID": containerID,
+		"Workload":    workload,
+		"HandleID":    handleID,
+	}).Debug("Generated IPAM handle")
+
+	return handleID, nil
 }
 
 func PopulateEndpointNets(endpoint *api.WorkloadEndpoint, result *current.Result) error {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Instead of just using the workload, we use the container network
namespace and the container ID combined to generate a unique handle to
track allocations.

Some questions before the WIP is removed:
- Should we be trimming off the path portion of the container network ns? It seems like so but I haven't done that yet.
- There was mention of separate code paths for k8s vs others, and it seems like they both lead back to `calico-ipam.go` so I feel like I've probably overlooked something in the code path for CNI
- If we trim out the path portion of the container net ns (and maybe even if not) I don't think there is any escaping that needs to be done
- Should we bother to check in `utils.GetHandleId()` for the container ID and network namespace as they are supposed to be a required part of the CNI spec (provided the orchestrators are all following it properly)?


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
