### PR TITLE
refine logic in case ls take too much time

### DIFF
--- a/k8s-install/scripts/install-cni.sh
+++ b/k8s-install/scripts/install-cni.sh
@@ -166,7 +166,7 @@ while [ "$should_sleep" == "true"  ]; do
 	# version to the host. Just check the timestamp on the certificate to see if it
 	# has been updated.  A bit hokey, but likely good enough.
 	current_stat_output=$(stat -c%y ${SECRETS_MOUNT_DIR}/etcd-cert 2>/dev/null)
-	if [ "$old_stat_output" != "$current_output" ]; then
+	if [ "$old_stat_output" != "$current_stat_output" ]; then
 		old_stat_output=$current_stat_output
 		echo "Updating installed secrets at: $(date)"
 		cp ${SECRETS_MOUNT_DIR}/* /host/etc/cni/net.d/calico-tls/

--- a/k8s-install/scripts/install-cni.sh
+++ b/k8s-install/scripts/install-cni.sh
@@ -168,8 +168,8 @@ while [ "$should_sleep" == "true"  ]; do
 	current_stat_output=$(stat -c%y ${SECRETS_MOUNT_DIR}/etcd-cert 2>/dev/null)
 	if [ "$old_stat_output" != "$current_output" ]; then
 		old_stat_output=$current_stat_output
-        echo "Updating installed secrets at: $(date)"
-        cp ${SECRETS_MOUNT_DIR}/* /host/etc/cni/net.d/calico-tls/
-    fi
+		echo "Updating installed secrets at: $(date)"
+		cp ${SECRETS_MOUNT_DIR}/* /host/etc/cni/net.d/calico-tls/
+	fi
 	sleep 10
 done

--- a/k8s-install/scripts/install-cni.sh
+++ b/k8s-install/scripts/install-cni.sh
@@ -160,19 +160,16 @@ echo "Created CNI config ${CNI_CONF_NAME}"
 # This prevents Kubernetes from restarting the pod repeatedly.
 should_sleep=${SLEEP:-"true"}
 echo "Done configuring CNI.  Sleep=$should_sleep"
+old_stat_output=$(stat -c%y ${SECRETS_MOUNT_DIR}/etcd-cert 2>/dev/null)
 while [ "$should_sleep" == "true"  ]; do
 	# Kubernetes Secrets can be updated.  If so, we need to install the updated
 	# version to the host. Just check the timestamp on the certificate to see if it
 	# has been updated.  A bit hokey, but likely good enough.
-	if [ "$(ls -A ${SECRETS_MOUNT_DIR} 2>/dev/null)" ];
-	then
-        stat_output=$(stat -c%y ${SECRETS_MOUNT_DIR}/etcd-cert 2>/dev/null)
-        sleep 10;
-        if [ "$stat_output" != "$(stat -c%y ${SECRETS_MOUNT_DIR}/etcd-cert 2>/dev/null)" ]; then
-            echo "Updating installed secrets at: $(date)"
-            cp ${SECRETS_MOUNT_DIR}/* /host/etc/cni/net.d/calico-tls/
-        fi
-    else
-        sleep 10
+	current_stat_output=$(stat -c%y ${SECRETS_MOUNT_DIR}/etcd-cert 2>/dev/null)
+	if [ "$old_stat_output" != "$current_output" ]; then
+		old_stat_output=$current_stat_output
+        echo "Updating installed secrets at: $(date)"
+        cp ${SECRETS_MOUNT_DIR}/* /host/etc/cni/net.d/calico-tls/
     fi
+	sleep 10
 done

--- a/k8s-install/scripts/install_cni_test.go
+++ b/k8s-install/scripts/install_cni_test.go
@@ -42,6 +42,7 @@ func runCniContainer(extraArgs ...string) error {
 		"-v", cwd + "/tmp/bin:/host/opt/cni/bin",
 		"-v", cwd + "/tmp/net.d:/host/etc/cni/net.d",
 		"-v", cwd + "/tmp/serviceaccount:/var/run/secrets/kubernetes.io/serviceaccount",
+		"-v", cwd + "/tmp/etcd-cert:/calico-secrets/etcd-cert",
 	}
 	args = append(args, extraArgs...)
 	image := fmt.Sprintf("%s", os.Getenv("DEPLOY_CONTAINER_NAME"))
@@ -67,6 +68,7 @@ func cleanup() {
 		"-v", cwd+"/tmp/bin:/host/opt/cni/bin",
 		"-v", cwd+"/tmp/net.d:/host/etc/cni/net.d",
 		"-v", cwd+"/tmp/serviceaccount:/var/run/secrets/kubernetes.io/serviceaccount",
+		"-v", cwd+"/tmp/etcd-cert:/calico-secrets/etcd-cert",
 		fmt.Sprintf("%s", os.Getenv("DEPLOY_CONTAINER_NAME")),
 		"sh", "-c", "rm -f /host/opt/cni/bin/* /host/etc/cni/net.d/*").CombinedOutput()
 
@@ -88,6 +90,10 @@ var _ = BeforeSuite(func() {
 	err = os.MkdirAll("tmp/serviceaccount", 0755)
 	if err != nil {
 		Fail("Failed to create directory tmp/serviceaccount")
+	}
+	err = os.MkdirAll("tmp/etcd-cert", 0755)
+	if err != nil {
+		Fail("Failed to create directory tmp/etcd-cert")
 	}
 	cleanup()
 


### PR DESCRIPTION
Signed-off-by: Pike <pikeszfish@gmail.com>

## Description
I think previous code logic will fail when `if [ "$(ls -A ${SECRETS_MOUNT_DIR} 2>/dev/null)" ];` take too much time and `stat_output ` will always be equal to the command `$(stat -c%y ${SECRETS_MOUNT_DIR}/etcd-cert 2>/dev/null)` executed 10 second later.
So I just refine them.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note
I will add anything is needed.

## Release Note
```
refine logic code in case `ls` take too much time
```