### PR TITLE
Un-pend multi-container test.

### DIFF
--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -411,6 +411,10 @@ func DeleteContainer(netconf, netnspath, podName, podNamespace string) (exitCode
 }
 
 func DeleteContainerWithId(netconf, netnspath, podName, podNamespace, containerId string) (exitCode int, err error) {
+	return DeleteContainerWithIdAndIfaceName(netconf, netnspath, podName, podNamespace, containerId, "eth0")
+}
+
+func DeleteContainerWithIdAndIfaceName(netconf, netnspath, podName, podNamespace, containerId, ifaceName string) (exitCode int, err error) {
 	netnsname := path.Base(netnspath)
 	container_id := netnsname[:10]
 	if containerId != "" {
@@ -426,12 +430,12 @@ func DeleteContainerWithId(netconf, netnspath, podName, podNamespace, containerI
 		"CNI_COMMAND=DEL",
 		fmt.Sprintf("CNI_CONTAINERID=%s", container_id),
 		fmt.Sprintf("CNI_NETNS=%s", netnspath),
-		"CNI_IFNAME=eth0",
+		"CNI_IFNAME=" + ifaceName,
 		fmt.Sprintf("CNI_PATH=%s", os.Getenv("DIST")),
 		k8sEnv,
 	}
 
-	log.Debugf("Calling CNI plugin with the following env vars: %v", env)
+	log.Debugf("Deleting container with ID %v CNI plugin with the following env vars: %v", containerId, env)
 
 	// Run the CNI plugin passing in the supplied netconf
 	subProcess := exec.Command(fmt.Sprintf("%s/%s", os.Getenv("DIST"), os.Getenv("PLUGIN")), netconf)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -77,7 +77,10 @@ func CreateOrUpdate(ctx context.Context, client client.Interface, wep *api.Workl
 func CleanUpNamespace(args *skel.CmdArgs, logger *logrus.Entry) error {
 	// Only try to delete the device if a namespace was passed in.
 	if args.Netns != "" {
-		logger.Debug("Checking namespace & device exist.")
+		logger.WithFields(logrus.Fields{
+			"netns": args.Netns,
+			"iface": args.IfName,
+		}).Debug("Checking namespace & device exist.")
 		devErr := ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {
 			_, err := netlink.LinkByName(args.IfName)
 			return err
@@ -94,7 +97,7 @@ func CleanUpNamespace(args *skel.CmdArgs, logger *logrus.Entry) error {
 				return err
 			}
 		} else {
-			logger.Info("veth does not exist, no need to clean up.")
+			logger.WithField("ifName", args.IfName).Info("veth does not exist, no need to clean up.")
 		}
 	}
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Fix and un-pend formerly flaky test.

The test was assuming that the name of the veth inside the container was always "eth0" but the CNI plugin now honours the requested interface name for the container veth, _even though it always stores the WEP with name "eth0"_.

Tearing it down with "eth0" was silently ignored (the CNI plugin couldn't find the interface so it assumed the tear down had already been done).

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
