### PR TITLE
Clean up superfluous Profile metadata labels

### DIFF
--- a/calico.go
+++ b/calico.go
@@ -331,8 +331,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 			profile := &api.Profile{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   conf.Name,
-					Labels: map[string]string{conf.Name: ""},
+					Name: conf.Name,
 				},
 				Spec: api.ProfileSpec{
 					Egress:        []api.Rule{{Action: api.Allow}},

--- a/calico_cni_test.go
+++ b/calico_cni_test.go
@@ -71,7 +71,7 @@ var _ = Describe("CalicoCni", func() {
 				// Profile is created with correct details
 				profile, err := calicoClient.Profiles().Get(ctx, "net1", options.GetOptions{})
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(profile.Labels).Should(Equal(map[string]string{"net1": ""}))
+				Expect(profile.Spec.LabelsToApply).Should(Equal(map[string]string{"net1": ""}))
 				Expect(profile.Spec.Egress).Should(Equal([]api.Rule{{Action: "Allow"}}))
 				Expect(profile.Spec.Ingress).Should(Equal([]api.Rule{{Action: "Allow", Source: api.EntityRule{Selector: "has(net1)"}}}))
 


### PR DESCRIPTION
The meaning that used to be attached to these labels is now with
Spec.LabelsToApply.

This is a cleanup that was requested during the review of
https://github.com/projectcalico/cni-plugin/pull/399.
