### PR TITLE
[WIP] Adds support to use Namespace annotation for ippools

### DIFF
--- a/calico_cni_k8s_test.go
+++ b/calico_cni_k8s_test.go
@@ -89,6 +89,15 @@ var _ = Describe("CalicoCni", func() {
 					panic(err)
 				}
 
+				// Create the Namespace before the tests
+				_, err = clientset.CoreV1().Namespaces().Create(&v1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "test",
+						Annotations: map[string]string{},
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+
 				name := fmt.Sprintf("run%d", rand.Uint32())
 
 				// Create a K8s pod w/o any special params
@@ -382,6 +391,162 @@ var _ = Describe("CalicoCni", func() {
 					Eventually(session).Should(gexec.Exit(0))
 
 					_, err = testutils.DeleteContainer(netconf, contNs.Path(), name, testutils.K8S_TEST_NS)
+					Expect(err).ShouldNot(HaveOccurred())
+				})
+			})
+
+			Context("using calico-ipam with a Namespace annotation only", func() {
+				It("successfully assigns an IP address from the annotated ipPool in Namespace", func() {
+					netconfCalicoIPAM := fmt.Sprintf(`
+				{
+			      "cniVersion": "%s",
+				  "name": "netnsannot1",
+				  "type": "calico",
+				  "etcd_endpoints": "http://%s:2379",
+			          "nodename_file_optional": true,
+				  "datastore_type": "%s",
+			 	  "ipam": {
+			    	 "type": "calico-ipam"
+			         },
+					"kubernetes": {
+					  "k8s_api_root": "http://127.0.0.1:8080"
+					 },
+					"policy": {"type": "k8s"},
+					"log_level":"info"
+				}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"))
+
+					// Create a new ipPool.
+					ipPool := "50.60.0.0/16"
+
+					testutils.MustCreateNewIPPool(calicoClient, ipPool, false, false, true)
+					_, ipPoolCIDR, err := net.ParseCIDR(ipPool)
+					Expect(err).NotTo(HaveOccurred())
+
+					config, err := clientcmd.DefaultClientConfig.ClientConfig()
+					Expect(err).NotTo(HaveOccurred())
+
+					clientset, err := kubernetes.NewForConfig(config)
+					Expect(err).NotTo(HaveOccurred())
+					// Create the Namespace before the tests
+					testNS := fmt.Sprintf("run%d", rand.Uint32())
+					_, err = clientset.CoreV1().Namespaces().Create(&v1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: testNS,
+							Annotations: map[string]string{
+								"cni.projectcalico.org/ipv4pools": "[\"50.60.0.0/16\"]",
+							},
+						},
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					// Now create a K8s pod passing in an IP pool.
+					name := fmt.Sprintf("run%d", rand.Uint32())
+					pod, err := clientset.CoreV1().Pods(testNS).Create(&v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        name,
+							Annotations: map[string]string{},
+						},
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{{
+								Name:  name,
+								Image: "ignore",
+							}},
+							NodeName: hostname,
+						},
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					log.Infof("Created POD object: %v", pod)
+
+					_, _, _, contAddresses, _, contNs, err := testutils.CreateContainer(netconfCalicoIPAM, name, testNS, "")
+					Expect(err).NotTo(HaveOccurred())
+
+					podIP := contAddresses[0].IP
+					log.Infof("All container IPs: %v", contAddresses)
+					log.Infof("Container got IP address: %s", podIP)
+					Expect(ipPoolCIDR.Contains(podIP)).To(BeTrue())
+
+					// Delete the container.
+					_, err = testutils.DeleteContainer(netconfCalicoIPAM, contNs.Path(), name, testNS)
+					Expect(err).ShouldNot(HaveOccurred())
+				})
+			})
+
+			Context("using calico-ipam with Namespace annotation and POD annotation", func() {
+				It("successfully assigns an IP address from the annotated ipPool in POD", func() {
+					netconfCalicoIPAM := fmt.Sprintf(`
+				{
+			      "cniVersion": "%s",
+				  "name": "netnsannot2",
+				  "type": "calico",
+				  "etcd_endpoints": "http://%s:2379",
+			          "nodename_file_optional": true,
+				  "datastore_type": "%s",
+			 	  "ipam": {
+			    	 "type": "calico-ipam"
+			         },
+					"kubernetes": {
+					  "k8s_api_root": "http://127.0.0.1:8080"
+					 },
+					"policy": {"type": "k8s"},
+					"log_level":"info"
+				}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"))
+
+					// Create a new ipPool.
+					ipPool := "50.70.0.0/16"
+
+					testutils.MustCreateNewIPPool(calicoClient, ipPool, false, false, true)
+					_, ipPoolCIDR, err := net.ParseCIDR(ipPool)
+					Expect(err).NotTo(HaveOccurred())
+
+					config, err := clientcmd.DefaultClientConfig.ClientConfig()
+					Expect(err).NotTo(HaveOccurred())
+
+					clientset, err := kubernetes.NewForConfig(config)
+					Expect(err).NotTo(HaveOccurred())
+					// Create the Namespace before the tests
+					testNS := fmt.Sprintf("run%d", rand.Uint32())
+					_, err = clientset.CoreV1().Namespaces().Create(&v1.Namespace{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: testNS,
+							Annotations: map[string]string{
+								"cni.projectcalico.org/ipv4pools": "[\"50.55.0.0/16\"]",
+							},
+						},
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					// Now create a K8s pod passing in an IP pool.
+					name := fmt.Sprintf("run%d", rand.Uint32())
+					pod, err := clientset.CoreV1().Pods(testNS).Create(&v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: name,
+							Annotations: map[string]string{
+								"cni.projectcalico.org/ipv4pools": "[\"50.70.0.0/16\"]",
+							},
+						},
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{{
+								Name:  name,
+								Image: "ignore",
+							}},
+							NodeName: hostname,
+						},
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					log.Infof("Created POD object: %v", pod)
+
+					_, _, _, contAddresses, _, contNs, err := testutils.CreateContainer(netconfCalicoIPAM, name, testNS, "")
+					Expect(err).NotTo(HaveOccurred())
+
+					podIP := contAddresses[0].IP
+					log.Infof("All container IPs: %v", contAddresses)
+					log.Infof("Container got IP address: %s", podIP)
+					Expect(ipPoolCIDR.Contains(podIP)).To(BeTrue())
+
+					// Delete the container.
+					_, err = testutils.DeleteContainer(netconfCalicoIPAM, contNs.Path(), name, testNS)
 					Expect(err).ShouldNot(HaveOccurred())
 				})
 			})

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -92,6 +92,8 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 
 	labels := make(map[string]string)
 	annot := make(map[string]string)
+	annotNS := make(map[string]string)
+
 	var ports []api.EndpointPort
 	var profiles []string
 	var generateName string
@@ -102,6 +104,12 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 	// Kubernetes API
 	if conf.Policy.PolicyType == "k8s" {
 		var err error
+
+		annotNS, err = getK8sNSInfo(client, epIDs.Namespace)
+		if err != nil {
+			return nil, err
+		}
+		logger.WithField("NS Annotations", annotNS).Debug("Fetched K8s namespace annotations")
 
 		labels, annot, ports, profiles, generateName, err = getK8sPodInfo(client, epIDs.Pod, epIDs.Namespace)
 		if err != nil {
@@ -115,8 +123,21 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 		// Check for calico IPAM specific annotations and set them if needed.
 		if conf.IPAM.Type == "calico-ipam" {
 
-			v4pools := annot["cni.projectcalico.org/ipv4pools"]
-			v6pools := annot["cni.projectcalico.org/ipv6pools"]
+			var v4pools, v6pools string
+
+			// Sets  the Namespace annotation for IP pools as default
+			v4pools = annotNS["cni.projectcalico.org/ipv4pools"]
+			v6pools = annotNS["cni.projectcalico.org/ipv6pools"]
+
+			// Gets the POD annotation for IP Pools and overwrites Namespace annotation if it exists
+			v4poolpod := annot["cni.projectcalico.org/ipv4pools"]
+			if len(v4poolpod) != 0 {
+				v4pools = v4poolpod
+			}
+			v6poolpod := annot["cni.projectcalico.org/ipv6pools"]
+			if len(v6poolpod) != 0 {
+				v6pools = v6poolpod
+			}
 
 			if len(v4pools) != 0 || len(v6pools) != 0 {
 				var stdinData map[string]interface{}
@@ -664,6 +685,15 @@ func newK8sClient(conf types.NetConf, logger *logrus.Entry) (*kubernetes.Clients
 
 	// Create the clientset
 	return kubernetes.NewForConfig(config)
+}
+
+func getK8sNSInfo(client *kubernetes.Clientset, podNamespace string) (annotations map[string]string, err error) {
+	ns, err := client.CoreV1().Namespaces().Get(podNamespace, metav1.GetOptions{})
+	logrus.Infof("namespace info %+v", ns)
+	if err != nil {
+		return nil, err
+	}
+	return ns.Annotations, nil
 }
 
 func getK8sPodInfo(client *kubernetes.Clientset, podName, podNamespace string) (labels map[string]string, annotations map[string]string, ports []api.EndpointPort, profiles []string, generateName string, err error) {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Type of fix: new feature

This PR adds support to global Namespace IP Pool allocations.

The main idea here is to allow the cluster administrator to define and/or force the usage of a specific ippool in some Namespace

The following workflow happens:

* If the POD is the only object annotated with ipv4/ipv6 pools, this annotation is used
* If the Namespace is the only object annotated with ipv4/ipv6 pools, namespace annotation is used
* If both the POD and Namespace are annotated with ipv4/ipv6 pools, POD annotation is used
* If both are annotated, but the additional annotation ``cni.projectcalico.org/forceNSPools`` is found as 'true', then the ipv4/ipv6 pools annotation from namespace is used
* If forceNSpool is found as 'true' but no ipv4/ipv6 annotation are found in the Namespace, no annotation is used and the default pools configured in CNI are used (probably this should be improved with a log message)

This is still a WIP but needs review and also a lot of tests.

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
