### PR TITLE
Sanitize mesos labels

### DIFF
--- a/calico_cni_test.go
+++ b/calico_cni_test.go
@@ -281,6 +281,130 @@ var _ = Describe("CalicoCni", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 			})
 		})
+
+		Context("Mesos Labels", func() {
+			It("applies mesos labels", func() {
+				netconf := fmt.Sprintf(`
+				{
+				  "cniVersion": "%s",
+				  "name": "net1",
+				  "type": "calico",
+				  "etcd_endpoints": "http://%s:2379",
+				  "hostname": "namedHostname",
+				  "ipam": {
+					"type": "host-local",
+					"subnet": "10.0.0.0/8"
+				  },
+				  "args": {
+					"org.apache.mesos": {
+					  "network_info": {
+						"labels": {
+						  "labels": [
+							{
+							  "key": "k",
+							  "value": "v"
+							}
+						  ]
+						}
+					  }
+					}
+				  }
+				}`, cniVersion, os.Getenv("ETCD_IP"))
+
+				containerID, session, _, _, _, contNs, err := CreateContainer(netconf, "", "")
+				Expect(err).ShouldNot(HaveOccurred())
+				Eventually(session).Should(gexec.Exit())
+
+				result, err := GetResultForCurrent(session, cniVersion)
+				if err != nil {
+					log.Fatalf("Error getting result from the session: %v\n", err)
+				}
+
+				log.Printf("Unmarshalled result: %v\n", result)
+
+				// The endpoint is created in etcd
+				endpoints, err := calicoClient.WorkloadEndpoints().List(api.WorkloadEndpointMetadata{})
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(endpoints.Items).Should(HaveLen(1))
+
+				// Set the Revision to nil since we can't assert it's exact value.
+				endpoints.Items[0].Metadata.Revision = nil
+				Expect(endpoints.Items[0].Metadata).Should(Equal(api.WorkloadEndpointMetadata{
+					Node:             "namedHostname",
+					Name:             "eth0",
+					Workload:         containerID,
+					ActiveInstanceID: "",
+					Orchestrator:     "cni",
+					Labels: map[string]string{
+						"k": "v",
+					},
+				}))
+
+				_, err = DeleteContainer(netconf, contNs.Path(), "")
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+
+			It("sanitizes mesos labels", func() {
+				netconf := fmt.Sprintf(`
+				{
+				  "cniVersion": "%s",
+				  "name": "net1",
+				  "type": "calico",
+				  "etcd_endpoints": "http://%s:2379",
+				  "hostname": "namedHostname",
+				  "ipam": {
+					"type": "host-local",
+					"subnet": "10.0.0.0/8"
+				  },
+				  "args": {
+					"org.apache.mesos": {
+					  "network_info": {
+						"labels": {
+						  "labels": [
+							{
+							  "key": "DCOS_SPACE",
+							  "value": "/a/b/c"
+							}
+						  ]
+						}
+					  }
+					}
+				  }
+				}`, cniVersion, os.Getenv("ETCD_IP"))
+
+				containerID, session, _, _, _, contNs, err := CreateContainer(netconf, "", "")
+				Expect(err).ShouldNot(HaveOccurred())
+				Eventually(session).Should(gexec.Exit())
+
+				result, err := GetResultForCurrent(session, cniVersion)
+				if err != nil {
+					log.Fatalf("Error getting result from the session: %v\n", err)
+				}
+
+				log.Printf("Unmarshalled result: %v\n", result)
+
+				// The endpoint is created in etcd
+				endpoints, err := calicoClient.WorkloadEndpoints().List(api.WorkloadEndpointMetadata{})
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(endpoints.Items).Should(HaveLen(1))
+
+				// Set the Revision to nil since we can't assert it's exact value.
+				endpoints.Items[0].Metadata.Revision = nil
+				Expect(endpoints.Items[0].Metadata).Should(Equal(api.WorkloadEndpointMetadata{
+					Node:             "namedHostname",
+					Name:             "eth0",
+					Workload:         containerID,
+					ActiveInstanceID: "",
+					Orchestrator:     "cni",
+					Labels: map[string]string{
+						"DCOS_SPACE": "a.b.c",
+					},
+				}))
+
+				_, err = DeleteContainer(netconf, contNs.Path(), "")
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+		})
 	})
 
 	Describe("Run Calico CNI plugin", func() {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -154,6 +154,32 @@ func CreateResultFromEndpoint(ep *api.WorkloadEndpoint) (*current.Result, error)
 	return result, nil
 }
 
+// SanitizeMesosLabel converts a string from a valid mesos label to a valid Calico label.
+// Mesos labels have no restriction outside of being unicode.
+func SanitizeMesosLabel(s string) string {
+	// Inspired by:
+	// https://github.com/projectcalico/libcalico-go/blob/2ff29bed865c4b364d4fcf1ad214b2bd8d9b4afa/lib/upgrade/converters/names.go#L39-L58
+	invalidChar := regexp.MustCompile("[^-_.a-zA-Z0-9]+")
+	dotDashSeq := regexp.MustCompile("[.-]*[.][.-]*")
+	trailingLeadingDotsDashes := regexp.MustCompile("^[.-]*(.*?)[.-]*$")
+
+	// -  Convert [/] to .
+	s = strings.Replace(s, "/", ".", -1)
+
+	// -  Convert any other invalid chars
+	s = invalidChar.ReplaceAllString(s, "-")
+
+	// Convert any multi-byte sequence of [-.] with at least one [.] to a single .
+	s = dotDashSeq.ReplaceAllString(s, ".")
+
+	// Extract the trailing and leading dots and dashes.   This should always match even if
+	// the matched substring is empty.  The second item in the returned submatch
+	// slice is the captured match group.
+	submatches := trailingLeadingDotsDashes.FindStringSubmatch(s)
+	s = submatches[1]
+	return s
+}
+
 func GetIdentifiers(args *skel.CmdArgs) (workloadID string, orchestratorID string, err error) {
 	// Determine if running under k8s by checking the CNI args
 	k8sArgs := K8sArgs{}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,23 @@
+package utils_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"github.com/projectcalico/cni-plugin/utils"
+)
+
+var _ = Describe("utils", func() {
+	table.DescribeTable("Mesos Labels", func(raw, sanitized string) {
+		result := utils.SanitizeMesosLabel(raw)
+		Expect(result).To(Equal(sanitized))
+	},
+		table.Entry("valid", "k", "k"),
+		table.Entry("dashes", "-my-val", "my-val"),
+		table.Entry("double periods", "$my..val", "my.val"),
+		table.Entry("special chars", "m$y.val", "m-y.val"),
+		table.Entry("slashes", "//my/val/", "my.val"),
+		table.Entry("mix of special chars",
+			"some_val-with.lots*of^weird#characters", "some_val-with.lots-of-weird-characters"),
+	)
+})


### PR DESCRIPTION
Slashes (`/`) are a valid character for Mesos labels.

This PR sanitizes slashes in Mesos labels by converting them to periods (`.`).