### PR TITLE
Sanitize mesos labels

### DIFF
--- a/calico.go
+++ b/calico.go
@@ -245,7 +245,12 @@ func cmdAdd(args *skel.CmdArgs) error {
 			// Parse endpoint labels passed in by Mesos, and store in a map.
 			labels := map[string]string{}
 			for _, label := range conf.Args.Mesos.NetworkInfo.Labels.Labels {
-				labels[label.Key] = label.Value
+				// Sanitize mesos labels so that they pass the k8s label validation,
+				// as mesos labels accept any unicode value.
+				k := utils.SanitizeMesosLabel(label.Key)
+				v := utils.SanitizeMesosLabel(label.Value)
+
+				labels[k] = v
 			}
 
 			// 2) Create the endpoint object

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,23 @@
+package utils_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"github.com/projectcalico/cni-plugin/utils"
+)
+
+var _ = Describe("utils", func() {
+	table.DescribeTable("Mesos Labels", func(raw, sanitized string) {
+		result := utils.SanitizeMesosLabel(raw)
+		Expect(result).To(Equal(sanitized))
+	},
+		table.Entry("valid", "k", "k"),
+		table.Entry("dashes", "-my-val", "my-val"),
+		table.Entry("double periods", "$my..val", "my.val"),
+		table.Entry("special chars", "m$y.val", "m-y.val"),
+		table.Entry("slashes", "//my/val/", "my.val"),
+		table.Entry("mix of special chars",
+			"some_val-with.lots*of^weird#characters", "some_val-with.lots-of-weird-characters"),
+	)
+})


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Port #467  to master.

## Todos
- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Sanitize mesos labels by stripping preceeding and succeeding slashes and converting the rest to periods.
```
