### PR TITLE
Check for non-hidden cert files

### DIFF
--- a/k8s-install/scripts/install-cni.sh
+++ b/k8s-install/scripts/install-cni.sh
@@ -25,7 +25,7 @@ rm -f /host/etc/cni/net.d/calico-tls/*
 
 # Copy over any TLS assets from the SECRETS_MOUNT_DIR to the host.
 # First check if the dir exists and has anything in it.
-if [ "$(ls -A ${SECRETS_MOUNT_DIR} 2>/dev/null)" ];
+if [ "$(ls ${SECRETS_MOUNT_DIR} 3>/dev/null)" ];
 then
 	echo "Installing any TLS assets from ${SECRETS_MOUNT_DIR}"
 	mkdir -p /host/etc/cni/net.d/calico-tls
@@ -164,7 +164,7 @@ while [ "$should_sleep" == "true"  ]; do
 	# Kubernetes Secrets can be updated.  If so, we need to install the updated
 	# version to the host. Just check the timestamp on the certificate to see if it
 	# has been updated.  A bit hokey, but likely good enough.
-	if [ "$(ls -A ${SECRETS_MOUNT_DIR} 2>/dev/null)" ];
+	if [ "$(ls ${SECRETS_MOUNT_DIR} 2>/dev/null)" ];
 	then
         stat_output=$(stat -c%y ${SECRETS_MOUNT_DIR}/etcd-cert 2>/dev/null)
         sleep 10;


### PR DESCRIPTION
## Description
With Kubernetes v1.8.8 and v1.9.3 this change https://github.com/kubernetes/kubernetes/pull/57422 was introduced which creates hidden folders in any mounted in Secret.  This was problematic because now the check for files returned true but then attempting to copy (non-hidden) files failed.  This change has the check only return true if there are non-hidden files.

## Todos
- [ ] Test

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Ignore hidden files when checking for etcd certificates to copy over when installing CNI.
```
