### PR TITLE
Use the /var/lib/calico/nodename file if it exists

### DIFF
--- a/calico_cni_k8s_test.go
+++ b/calico_cni_k8s_test.go
@@ -73,6 +73,7 @@ var _ = Describe("CalicoCni", func() {
 			    "k8s_api_root": "http://127.0.0.1:8080"
 			  },
 			  "policy": {"type": "k8s"},
+			  "nodename_file_optional": true,
 			  "log_level":"info"
 			}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"))
 
@@ -392,6 +393,7 @@ var _ = Describe("CalicoCni", func() {
 				  "name": "net2",
 				  "type": "calico",
 				  "etcd_endpoints": "http://%s:2379",
+			          "nodename_file_optional": true,
 				  "datastore_type": "%s",
 			 	  "ipam": {
 			    	 "type": "calico-ipam"
@@ -460,6 +462,7 @@ var _ = Describe("CalicoCni", func() {
 				  "type": "calico",
 				  "etcd_endpoints": "http://%s:2379",
 				  "datastore_type": "%s",
+			          "nodename_file_optional": true,
 			 	  "ipam": {},
 					"kubernetes": {
 					  "k8s_api_root": "http://127.0.0.1:8080"
@@ -560,6 +563,7 @@ var _ = Describe("CalicoCni", func() {
 				  "type": "calico",
 				  "etcd_endpoints": "http://%s:2379",
 				  "datastore_type": "%s",
+			          "nodename_file_optional": true,
 				  "ipam": {
 					   "type": "calico-ipam",
 					   "assign_ipv4": "true",
@@ -668,6 +672,7 @@ var _ = Describe("CalicoCni", func() {
 				  "type": "calico",
 				  "etcd_endpoints": "http://%s:2379",
 				  "datastore_type": "%s",
+			          "nodename_file_optional": true,
 				  "ipam": {
 					   "type": "calico-ipam",
 					   "assign_ipv4": "true",
@@ -774,6 +779,7 @@ var _ = Describe("CalicoCni", func() {
 				  {
 					"cniVersion": "%s",
 					"name": "net6",
+           			          "nodename_file_optional": true,
 					  "type": "calico",
 					  "etcd_endpoints": "http://%s:2379",
 					  "datastore_type": "%s",
@@ -867,6 +873,7 @@ var _ = Describe("CalicoCni", func() {
 				  "type": "calico",
 				  "etcd_endpoints": "http://%s:2379",
 				  "datastore_type": "%s",
+           			  "nodename_file_optional": true,
 			 	  "ipam": {
 			    	 "type": "calico-ipam"
 			         },
@@ -1032,6 +1039,7 @@ var _ = Describe("CalicoCni", func() {
 				  "type": "calico",
 				  "etcd_endpoints": "http://%s:2379",
 				  "datastore_type": "%s",
+           			  "nodename_file_optional": true,
 			 	  "ipam": {
 			    	 "type": "calico-ipam"
 			         },
@@ -1190,6 +1198,7 @@ var _ = Describe("CalicoCni", func() {
 							"type": "calico",
 							"etcd_endpoints": "http://%s:2379",
 							"datastore_type": "%s",
+           			                        "nodename_file_optional": true,
 							"ipam": {
 									"type": "calico-ipam"
 									},
@@ -1357,6 +1366,7 @@ var _ = Describe("CalicoCni", func() {
 				  "type": "calico",
 				  "etcd_endpoints": "http://%s:2379",
 				  "datastore_type": "%s",
+           			  "nodename_file_optional": true,
 			 	  "ipam": {},
 					"kubernetes": {
 					  "k8s_api_root": "http://127.0.0.1:8080"
@@ -1414,6 +1424,7 @@ var _ = Describe("CalicoCni", func() {
 				  "type": "calico",
 				  "etcd_endpoints": "http://%s:2379",
 				  "datastore_type": "%s",
+           			  "nodename_file_optional": true,
 				  "log_level": "debug",
 			 	  "ipam": {
 				    "type": "calico-ipam"

--- a/calico_cni_test.go
+++ b/calico_cni_test.go
@@ -45,6 +45,7 @@ var _ = Describe("CalicoCni", func() {
 			  "type": "calico",
 			  "etcd_endpoints": "http://%s:2379",
 			  "log_level": "debug",
+			  "nodename_file_optional": true,
 			  "datastore_type": "%s",
 			  "ipam": {
 			    "type": "host-local",
@@ -262,6 +263,7 @@ var _ = Describe("CalicoCni", func() {
 			  "type": "calico",
 			  "etcd_endpoints": "http://%s:2379",
 			  "hostname": "named-hostname.somewhere",
+			  "nodename_file_optional": true,
 			  "datastore_type": "%s",
 			  "ipam": {
 			    "type": "host-local",
@@ -315,6 +317,7 @@ var _ = Describe("CalicoCni", func() {
 				  "type": "calico",
 				  "etcd_endpoints": "http://%s:2379",
 				  "hostname": "named-hostname.somewhere",
+			          "nodename_file_optional": true,
 				  "ipam": {
 					"type": "host-local",
 					"subnet": "10.0.0.0/8"
@@ -363,6 +366,7 @@ var _ = Describe("CalicoCni", func() {
 				  "type": "calico",
 				  "etcd_endpoints": "http://%s:2379",
 				  "hostname": "named-hostname.somewhere",
+			          "nodename_file_optional": true,
 				  "ipam": {
 					"type": "host-local",
 					"subnet": "10.0.0.0/8"
@@ -415,6 +419,7 @@ var _ = Describe("CalicoCni", func() {
 			  "etcd_endpoints": "http://%s:2379",
 			  "hostname": "named-hostname",
 			  "nodename": "named-nodename",
+			  "nodename_file_optional": true,
 			  "datastore_type": "%s",
 			  "ipam": {
 			    "type": "host-local",
@@ -468,6 +473,7 @@ var _ = Describe("CalicoCni", func() {
 			"name": "net1",
 			"type": "calico",
 			"etcd_endpoints": "http://%s:2379",
+			"nodename_file_optional": true,
 			"datastore_type": "%s",
 			"ipam": {
 				"type": "host-local",
@@ -505,6 +511,7 @@ var _ = Describe("CalicoCni", func() {
 		  "etcd_endpoints": "http://%s:2379",
 		  "datastore_type": "%s",
 		  "log_level": "debug",
+	          "nodename_file_optional": true,
 		  "ipam": { "type": "calico-ipam" }
 		}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"))
 
@@ -672,6 +679,7 @@ var _ = Describe("CalicoCni", func() {
 			    "type": "host-local",
 			    "subnet": "10.0.0.0/8"
 			  },
+			  "nodename_file_optional": true,
 			  "log_level":"debug"
 			}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"))
 

--- a/types/types.go
+++ b/types/types.go
@@ -69,23 +69,24 @@ type NetConf struct {
 		IPv4Pools  []string `json:"ipv4_pools,omitempty"`
 		IPv6Pools  []string `json:"ipv6_pools,omitempty"`
 	} `json:"ipam,omitempty"`
-	MTU            int        `json:"mtu"`
-	Hostname       string     `json:"hostname"`
-	Nodename       string     `json:"nodename"`
-	DatastoreType  string     `json:"datastore_type"`
-	EtcdAuthority  string     `json:"etcd_authority"`
-	EtcdEndpoints  string     `json:"etcd_endpoints"`
-	LogLevel       string     `json:"log_level"`
-	Policy         Policy     `json:"policy"`
-	Kubernetes     Kubernetes `json:"kubernetes"`
-	Args           Args       `json:"args"`
-	EtcdScheme     string     `json:"etcd_scheme"`
-	EtcdKeyFile    string     `json:"etcd_key_file"`
-	EtcdCertFile   string     `json:"etcd_cert_file"`
-	EtcdCaCertFile string     `json:"etcd_ca_cert_file"`
+	MTU                  int        `json:"mtu"`
+	Hostname             string     `json:"hostname"`
+	Nodename             string     `json:"nodename"`
+	NodenameFileOptional bool       `json:"nodename_file_optional"`
+	DatastoreType        string     `json:"datastore_type"`
+	EtcdAuthority        string     `json:"etcd_authority"`
+	EtcdEndpoints        string     `json:"etcd_endpoints"`
+	LogLevel             string     `json:"log_level"`
+	Policy               Policy     `json:"policy"`
+	Kubernetes           Kubernetes `json:"kubernetes"`
+	Args                 Args       `json:"args"`
+	EtcdScheme           string     `json:"etcd_scheme"`
+	EtcdKeyFile          string     `json:"etcd_key_file"`
+	EtcdCertFile         string     `json:"etcd_cert_file"`
+	EtcdCaCertFile       string     `json:"etcd_ca_cert_file"`
 }
 
-// CNITestArgs is the CNI_ARGS used for test purpose.
+// CNITestArgs is the CNI_ARGS used for test purposes.
 type CNITestArgs struct {
 	types.CommonArgs
 	CNI_TEST_NAMESPACE types.UnmarshallableString


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

In combination with https://github.com/projectcalico/calico/pull/1722, will make it much harder to accidentally end up with mismatched node names between the two components.

Fixes https://github.com/projectcalico/calico/issues/1093


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
The Calico CNI plugin by default expects the /var/lib/calico/nodename file to be created by calico/node. To disable this feature, set `nodename_file_optional: true` in your CNI network configuration.
```
