### PR TITLE
Improve secret copy + kubeconfig permissions 

### DIFF
--- a/k8s-install/scripts/install-cni.sh
+++ b/k8s-install/scripts/install-cni.sh
@@ -29,7 +29,7 @@ if [ "$(ls ${SECRETS_MOUNT_DIR} 3>/dev/null)" ];
 then
 	echo "Installing any TLS assets from ${SECRETS_MOUNT_DIR}"
 	mkdir -p /host/etc/cni/net.d/calico-tls
-	cp ${SECRETS_MOUNT_DIR}/* /host/etc/cni/net.d/calico-tls/
+	cp -p ${SECRETS_MOUNT_DIR}/* /host/etc/cni/net.d/calico-tls/
 fi
 
 # If the TLS assets actually exist, update the variables to populate into the
@@ -96,20 +96,38 @@ ${CNI_NETWORK_CONFIG:-}
 EOF
 fi
 
-# Write a kubeconfig file for the CNI plugin.  Do this
-# to skip TLS verification for now.  We should eventually support
-# writing more complete kubeconfig files. This is only used
-# if the provided CNI network config references it.
-cat > /host/etc/cni/net.d/calico-kubeconfig <<EOF
+# Pull out service account token.
+SERVICEACCOUNT_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+
+# Check if we're running as a k8s pod.
+if [ -f "/var/run/secrets/kubernetes.io/serviceaccount/token" ]; then
+	# We're running as a k8d pod - expect some variables.
+	if [ -z ${KUBERNETES_SERVICE_HOST} ]; then 
+		echo "KUBERNETES_SERVICE_HOST not set"; exit 1;
+	fi
+	if [ -z ${KUBERNETES_SERVICE_PORT} ]; then
+		echo "KUBERNETES_SERVICE_PORT not set"; exit 1;
+	fi
+
+	# Write a kubeconfig file for the CNI plugin.  Do this
+	# to skip TLS verification for now.  We should eventually support
+	# writing more complete kubeconfig files. This is only used
+	# if the provided CNI network config references it.
+	touch /host/etc/cni/net.d/calico-kubeconfig
+	chmod ${KUBECONFIG_MODE:-600} /host/etc/cni/net.d/calico-kubeconfig
+	cat > /host/etc/cni/net.d/calico-kubeconfig <<EOF
 # Kubeconfig file for Calico CNI plugin.
 apiVersion: v1
 kind: Config
 clusters:
 - name: local
   cluster:
+    server: ${KUBERNETES_SERVICE_PROTOCOL:-https}://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT} 
     insecure-skip-tls-verify: true
 users:
 - name: calico
+  user:
+    token: "${SERVICEACCOUNT_TOKEN}" 
 contexts:
 - name: calico-context
   context:
@@ -118,8 +136,10 @@ contexts:
 current-context: calico-context
 EOF
 
+fi
+
+
 # Insert any of the supported "auto" parameters.
-SERVICEACCOUNT_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
 grep "__KUBERNETES_SERVICE_HOST__" $TMP_CONF && sed -i s/__KUBERNETES_SERVICE_HOST__/${KUBERNETES_SERVICE_HOST}/g $TMP_CONF
 grep "__KUBERNETES_SERVICE_PORT__" $TMP_CONF && sed -i s/__KUBERNETES_SERVICE_PORT__/${KUBERNETES_SERVICE_PORT}/g $TMP_CONF
 sed -i s/__KUBERNETES_NODE_NAME__/${KUBERNETES_NODE_NAME:-$(hostname)}/g $TMP_CONF
@@ -170,7 +190,7 @@ while [ "$should_sleep" == "true"  ]; do
         sleep 10;
         if [ "$stat_output" != "$(stat -c%y ${SECRETS_MOUNT_DIR}/etcd-cert 2>/dev/null)" ]; then
             echo "Updating installed secrets at: $(date)"
-            cp ${SECRETS_MOUNT_DIR}/* /host/etc/cni/net.d/calico-tls/
+            cp -p ${SECRETS_MOUNT_DIR}/* /host/etc/cni/net.d/calico-tls/
         fi
     else
         sleep 10


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

A few improvements to our install CNI script:

- Copy secrets with `-p` to retain permissions (See https://github.com/projectcalico/cni-plugin/issues/459)
- Set `calico-kubeconfig` mode to `0600` by default
- Move token + API location into calico-kubeconfig file.


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
The install-cni container now maintains the original mode on certificates copied from Kubernetes secrets.
```

```release-note
The install-cni container now writes the calico-kubeconfig file with mode 600 by default. It can be configured by setting the KUBECONFIG_MODE option.
```

```release-note
The install-cni container now only writes the calico-kubeconfig file when running as a Kubernetes pod.
```
