### PR TITLE
Handle termination signals in install-cni

### DIFF
--- a/k8s-install/scripts/install-cni.sh
+++ b/k8s-install/scripts/install-cni.sh
@@ -8,6 +8,11 @@
 # Ensure all variables are defined, and that the script fails when an error is hit.
 set -u -e
 
+# Capture the usual signals and exit from the script
+trap 'echo "SIGINT received, simply exiting..."; exit 0' SIGINT
+trap 'echo "SIGTERM received, simply exiting..."; exit 0' SIGTERM
+trap 'echo "SIGHUP received, simply exiting..."; exit 0' SIGHUP
+
 # The directory on the host where CNI networks are installed. Defaults to
 # /etc/cni/net.d, but can be overridden by setting CNI_NET_DIR.  This is used
 # for populating absolute paths in the CNI network config to assets


### PR DESCRIPTION
- Fixes #1294
- Added trap handling for SIGTERM, SIGHUP and SIGINT

## Description
### type of fix
Bug Fix for #1294
- Why?
Adds signal handling as per the bug request
- Testing: Manual
```
# Tried these two commands:
$ kubectl delete daemonset calico-node --namespace kube-system --timeout=5s
$ kubectl delete pod calico-node-vjtw9 --grace-period=1 --namespace kube-system

# Following log is shown while exiting..
$ kubectl log -f calico-node-4djtb --container install-cni --namespace kube-system
...
...
}
Created CNI config 10-calico.conflist
Done configuring CNI.  Sleep=true

SIGTERM received, simply exiting...
```
- which components are affected by this PR
Dont know but should not be impacted.
- links to issues that this PR addresses
#1294

## Notes:
kubectl delete ds / pod only does not give SIGTERM to the container.
These commands with timeout or grace-period only signaled the container with SIGTERM
Also using kubectl cmd; was not able to generate SIGINT and SIGHUP signals.

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
