### PR TITLE
Ensure kubeconfig server works for IPv6

### DIFF
--- a/k8s-install/scripts/install-cni.sh
+++ b/k8s-install/scripts/install-cni.sh
@@ -102,7 +102,7 @@ SERVICEACCOUNT_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
 # Check if we're running as a k8s pod.
 if [ -f "/var/run/secrets/kubernetes.io/serviceaccount/token" ]; then
 	# We're running as a k8d pod - expect some variables.
-	if [ -z ${KUBERNETES_SERVICE_HOST} ]; then 
+	if [ -z ${KUBERNETES_SERVICE_HOST} ]; then
 		echo "KUBERNETES_SERVICE_HOST not set"; exit 1;
 	fi
 	if [ -z ${KUBERNETES_SERVICE_PORT} ]; then
@@ -122,12 +122,12 @@ kind: Config
 clusters:
 - name: local
   cluster:
-    server: ${KUBERNETES_SERVICE_PROTOCOL:-https}://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT} 
+    server: ${KUBERNETES_SERVICE_PROTOCOL:-https}://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}
     insecure-skip-tls-verify: true
 users:
 - name: calico
   user:
-    token: "${SERVICEACCOUNT_TOKEN}" 
+    token: "${SERVICEACCOUNT_TOKEN}"
 contexts:
 - name: calico-context
   context:


### PR DESCRIPTION
## Description
I realized with the recent CNI updates #481, that we needed this update since we can't make this change in the manifest anymore.

## Testing
I created an IPv4 cluster and modified the CNI config to removed the k8s_api_root and auth_token and added them to calico-kubeconfig with this format and was still able to delete and start pods on the node.  I did this to verify that the format would work for IPv4.

## Release Note

```release-note
None required
```
