### PR TITLE
cherry-pick 482: Handle termination signals in install-cni

### DIFF
--- a/k8s-install/scripts/install-cni.sh
+++ b/k8s-install/scripts/install-cni.sh
@@ -8,6 +8,11 @@
 # Ensure all variables are defined, and that the script fails when an error is hit.
 set -u -e
 
+# Capture the usual signals and exit from the script
+trap 'echo "SIGINT received, simply exiting..."; exit 0' SIGINT
+trap 'echo "SIGTERM received, simply exiting..."; exit 0' SIGTERM
+trap 'echo "SIGHUP received, simply exiting..."; exit 0' SIGHUP
+
 # The directory on the host where CNI networks are installed. Defaults to
 # /etc/cni/net.d, but can be overridden by setting CNI_NET_DIR.  This is used
 # for populating absolute paths in the CNI network config to assets


### PR DESCRIPTION
- Added trap handling for SIGTERM, SIGHUP and SIGINT

Cherry pick of #482 

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fixes a bug where the calico/cni container would ignore termination signals. @ketkulka 
```
