### PR TITLE
Pick profiles from libcalico-go.

### DIFF
--- a/calico_cni_k8s_test.go
+++ b/calico_cni_k8s_test.go
@@ -1625,6 +1625,127 @@ var _ = Describe("CalicoCni", func() {
 					Expect(ep.Spec.ContainerID).Should(Equal(containerID2))
 				})
 			})
+
+			Context("when pod has a service account", func() {
+				It("should add a service account profile to the workload endpoint", func() {
+					config, err := clientcmd.DefaultClientConfig.ClientConfig()
+					if err != nil {
+						panic(err)
+					}
+					clientset, err := kubernetes.NewForConfig(config)
+					if err != nil {
+						panic(err)
+					}
+
+					name := fmt.Sprintf("run%d", rand.Uint32())
+
+					// Create a K8s service account
+					saName := "testserviceaccount"
+					_, err = clientset.CoreV1().ServiceAccounts(testutils.K8S_TEST_NS).Create(&v1.ServiceAccount{
+						ObjectMeta: metav1.ObjectMeta{Name: saName},
+					})
+					if err != nil {
+						panic(err)
+					}
+
+					// Create a K8s pod with the service account
+					_, err = clientset.CoreV1().Pods(testutils.K8S_TEST_NS).Create(&v1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: name},
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{{
+								Name:  fmt.Sprintf("container-%s", name),
+								Image: "ignore",
+								Ports: []v1.ContainerPort{{
+									Name:          "anamedport",
+									ContainerPort: 555,
+								}},
+							}},
+							ServiceAccountName: saName,
+							NodeName:           hostname,
+						},
+					})
+					if err != nil {
+						panic(err)
+					}
+					containerID, session, contVeth, _, _, contNs, err := testutils.CreateContainer(netconf, name, testutils.K8S_TEST_NS, "")
+
+					Expect(err).ShouldNot(HaveOccurred())
+					Eventually(session).Should(gexec.Exit())
+
+					result, err := testutils.GetResultForCurrent(session, cniVersion)
+					if err != nil {
+						log.Fatalf("Error getting result from the session: %v\n", err)
+					}
+
+					mac := contVeth.Attrs().HardwareAddr
+
+					Expect(len(result.IPs)).Should(Equal(1))
+
+					ids := names.WorkloadEndpointIdentifiers{
+						Node:         hostname,
+						Orchestrator: api.OrchestratorKubernetes,
+						Endpoint:     "eth0",
+						Pod:          name,
+						ContainerID:  containerID,
+					}
+
+					wrkload, err := ids.CalculateWorkloadEndpointName(false)
+					interfaceName := k8sconversion.VethNameForWorkload(testutils.K8S_TEST_NS, name)
+					Expect(err).NotTo(HaveOccurred())
+
+					// The endpoint is created
+					endpoints, err := calicoClient.WorkloadEndpoints().List(ctx, options.ListOptions{})
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(endpoints.Items).Should(HaveLen(1))
+
+					Expect(endpoints.Items[0].Name).Should(Equal(wrkload))
+					Expect(endpoints.Items[0].Namespace).Should(Equal(testutils.K8S_TEST_NS))
+					Expect(endpoints.Items[0].Labels).Should(Equal(map[string]string{
+						"projectcalico.org/namespace":      "test",
+						"projectcalico.org/serviceaccount": saName,
+						"projectcalico.org/orchestrator":   api.OrchestratorKubernetes,
+					}))
+					Expect(endpoints.Items[0].Spec).Should(Equal(api.WorkloadEndpointSpec{
+						Pod:           name,
+						InterfaceName: interfaceName,
+						IPNetworks:    []string{result.IPs[0].Address.String()},
+						MAC:           mac.String(),
+						Profiles:      []string{"kns.test", "ksa.test." + saName},
+						Node:          hostname,
+						Endpoint:      "eth0",
+						Workload:      "",
+						ContainerID:   containerID,
+						Orchestrator:  api.OrchestratorKubernetes,
+						Ports: []api.EndpointPort{{
+							Name:     "anamedport",
+							Protocol: numorstring.ProtocolFromString("TCP"),
+							Port:     555,
+						}},
+					}))
+
+					_, err = testutils.DeleteContainer(netconf, contNs.Path(), name, testutils.K8S_TEST_NS)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					// Make sure there are no endpoints anymore
+					endpoints, err = calicoClient.WorkloadEndpoints().List(ctx, options.ListOptions{})
+					Expect(err).ShouldNot(HaveOccurred())
+					Expect(endpoints.Items).Should(HaveLen(0))
+
+					// Make sure the interface has been removed from the namespace
+					targetNs, _ := ns.GetNS(contNs.Path())
+					err = targetNs.Do(func(_ ns.NetNS) error {
+						_, err = netlink.LinkByName("eth0")
+						return err
+					})
+					Expect(err).Should(HaveOccurred())
+					Expect(err.Error()).Should(Equal("Link not found"))
+
+					// Make sure the interface has been removed from the host
+					_, err = netlink.LinkByName("cali" + containerID)
+					Expect(err).Should(HaveOccurred())
+					Expect(err.Error()).Should(Equal("Link not found"))
+				})
+			})
 		})
 	})
 })

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: d82f9428a3e985deb50f6ba8900c88cc94210f16d6d14df4664eb190d2ce015e
-updated: 2018-04-02T18:13:31.90671579Z
+hash: e84a8c3dbfc278ace067288b75793dbc92ca5e49613cf56dbbf7d3e399ed4b90
+updated: 2018-04-03T11:30:44.657129527-07:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -191,7 +191,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 88291609bbefd0fe22982a7a78ec51d63583a651
+  version: 9070d94a5bf7214a417372890fa0ad28eb13e813
   subpackages:
   - lib/apiconfig
   - lib/apis/v1
@@ -253,11 +253,11 @@ imports:
 - name: github.com/spf13/pflag
   version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/vishvananda/netlink
-  version: fe3b5664d23a11b52ba59bece4ff29c52772a56b
+  version: 6e453822d85ef5721799774b654d4d02fed62afb
   subpackages:
   - nl
 - name: github.com/vishvananda/netns
-  version: 8ba1072b58e0c2a240eb5f6120165c7776c3e7b8
+  version: 54f0e4339ce73702a0607f49922aaa1e749b418d
 - name: golang.org/x/crypto
   version: 1351f936d976c60a0a48d728281922cf63eafb8d
   subpackages:
@@ -383,7 +383,7 @@ imports:
   - storage/v1
   - storage/v1beta1
 - name: k8s.io/apimachinery
-  version: ab7fc865fb0881d161f37adef3e5a67b89a18d05
+  version: 4972c8e335e32ab65ba45bde0a99c6544c8a8e4c
   subpackages:
   - pkg/api/equality
   - pkg/api/errors

--- a/glide.yaml
+++ b/glide.yaml
@@ -24,7 +24,7 @@ import:
 - package: github.com/prometheus/procfs
   version: f98634e408857669d61064b283c4cde240622865
 - package: github.com/projectcalico/libcalico-go
-  version: 88291609bbefd0fe22982a7a78ec51d63583a651
+  version: 9070d94a5bf7214a417372890fa0ad28eb13e813
   subpackages:
   - lib/apiconfig
   - lib/apis/v2

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -106,6 +106,7 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 		labels := make(map[string]string)
 		annot := make(map[string]string)
 		var ports []api.EndpointPort
+		var profiles []string
 
 		// Only attempt to fetch the labels and annotations from Kubernetes
 		// if the policy type has been set to "k8s". This allows users to
@@ -114,13 +115,14 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 		if conf.Policy.PolicyType == "k8s" {
 			var err error
 
-			labels, annot, ports, err = getK8sPodInfo(client, epIDs.Pod, epIDs.Namespace)
+			labels, annot, ports, profiles, err = getK8sPodInfo(client, epIDs.Pod, epIDs.Namespace)
 			if err != nil {
 				return nil, err
 			}
 			logger.WithField("labels", labels).Debug("Fetched K8s labels")
 			logger.WithField("annotations", annot).Debug("Fetched K8s annotations")
 			logger.WithField("ports", ports).Debug("Fetched K8s ports")
+			logger.WithField("profiles", profiles).Debug("Generated profiles")
 
 			// Check for calico IPAM specific annotations and set them if needed.
 			if conf.IPAM.Type == "calico-ipam" {
@@ -252,9 +254,9 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 
 		// Set the profileID according to whether Kubernetes policy is required.
 		// If it's not, then just use the network name (which is the normal behavior)
-		// otherwise use one based on the Kubernetes pod's Namespace.
+		// otherwise use one based on the Kubernetes pod's profile(s).
 		if conf.Policy.PolicyType == "k8s" {
-			endpoint.Spec.Profiles = []string{k8sconversion.NamespaceProfileNamePrefix + epIDs.Namespace}
+			endpoint.Spec.Profiles = profiles
 		} else {
 			endpoint.Spec.Profiles = []string{conf.Name}
 		}
@@ -643,23 +645,24 @@ func newK8sClient(conf types.NetConf, logger *logrus.Entry) (*kubernetes.Clients
 	return kubernetes.NewForConfig(config)
 }
 
-func getK8sPodInfo(client *kubernetes.Clientset, podName, podNamespace string) (labels map[string]string, annotations map[string]string, ports []api.EndpointPort, err error) {
+func getK8sPodInfo(client *kubernetes.Clientset, podName, podNamespace string) (labels map[string]string, annotations map[string]string, ports []api.EndpointPort, profiles []string, err error) {
 	pod, err := client.CoreV1().Pods(string(podNamespace)).Get(podName, metav1.GetOptions{})
 	logrus.Infof("pod info %+v", pod)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	var c k8sconversion.Converter
 	kvp, err := c.PodToWorkloadEndpoint(pod)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	ports = kvp.Value.(*api.WorkloadEndpoint).Spec.Ports
 	labels = kvp.Value.(*api.WorkloadEndpoint).Labels
+	profiles = kvp.Value.(*api.WorkloadEndpoint).Spec.Profiles
 
-	return labels, pod.Annotations, ports, nil
+	return labels, pod.Annotations, ports, profiles, nil
 }
 
 func getPodCidr(client *kubernetes.Clientset, conf types.NetConf, nodename string) (string, error) {


### PR DESCRIPTION
## Description
Pick up the profiles from `libcalico-go`. That way we pick up all profiles including ServiceAccounts.
Added a test to check for service account profiles and pushed up the pin for `libcalico-go`