### PR TITLE
Allow sysctl configuration

### DIFF
--- a/calico.go
+++ b/calico.go
@@ -362,7 +362,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		}
 	}
 
-	// Set Gateway to nil. Calico-IPAM doesn't set it, but host-local does.
+	// Set Gateway to nil. Calico IPAM doesn't set it, but host-local does.
 	// We modify IPs subnet received from the IPAM plugin (host-local),
 	// so Gateway isn't valid anymore. It is also not used anywhere by Calico.
 	for _, ip := range result.IPs {

--- a/calico_cni_test.go
+++ b/calico_cni_test.go
@@ -127,6 +127,13 @@ var _ = Describe("CalicoCni", func() {
 				err = testutils.CheckSysctlValue(fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/forwarding", hostVethName), "1")
 				Expect(err).ShouldNot(HaveOccurred())
 
+				// Assert the container sysctl values are set to what we expect for IPv4.
+				targetNs, _ := ns.GetNS(contNs.Path())
+				err = targetNs.Do(func(_ ns.NetNS) error {
+					return testutils.CheckSysctlValue("/proc/sys/net/ipv4/ip_forward", "0")
+				})
+				Expect(err).ShouldNot(HaveOccurred())
+
 				// Assert if the host side route is programmed correctly.
 				hostRoutes, err := netlink.RouteList(hostVeth, syscall.AF_INET)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -169,7 +176,6 @@ var _ = Describe("CalicoCni", func() {
 				Expect(endpoints.Items).Should(HaveLen(0))
 
 				// Make sure the interface has been removed from the namespace
-				targetNs, _ := ns.GetNS(contNs.Path())
 				err = targetNs.Do(func(_ ns.NetNS) error {
 					_, err = netlink.LinkByName("eth0")
 					return err
@@ -250,6 +256,49 @@ var _ = Describe("CalicoCni", func() {
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(exitCode).ShouldNot(Equal(0))
 				})
+			})
+		})
+	})
+
+	Context("With IP forwarding enabled", func() {
+		netconf := fmt.Sprintf(`
+			{
+			  "cniVersion": "%s",
+			  "name": "net1",
+			  "type": "calico",
+			  "etcd_endpoints": "http://%s:2379",
+			  "log_level": "debug",
+			  "nodename_file_optional": true,
+			  "datastore_type": "%s",
+			  "container_settings": {
+			    "allow_ip_forwarding": true
+			  },
+			  "ipam": {
+			    "type": "host-local",
+			    "subnet": "10.0.0.0/8"
+			  }
+			}`, cniVersion, os.Getenv("ETCD_IP"), os.Getenv("DATASTORE_TYPE"))
+
+		It("should enable IPv4 forwarding", func() {
+			containerID := fmt.Sprintf("con%d", rand.Uint32())
+			_, session, _, _, _, contNs, err := testutils.CreateContainerWithId(netconf, "", testutils.TEST_DEFAULT_NS, "", containerID)
+
+			By("successfully networking the container", func() {
+				Expect(err).ShouldNot(HaveOccurred())
+				Eventually(session).Should(gexec.Exit(0))
+			})
+
+			By("asserting IPv4 forwarding is enabled", func() {
+				targetNs, _ := ns.GetNS(contNs.Path())
+				err = targetNs.Do(func(_ ns.NetNS) error {
+					return testutils.CheckSysctlValue("/proc/sys/net/ipv4/ip_forward", "1")
+				})
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+
+			By("tearing down the container", func() {
+				_, err = testutils.DeleteContainerWithId(netconf, contNs.Path(), "", testutils.TEST_DEFAULT_NS, containerID)
+				Expect(err).ShouldNot(HaveOccurred())
 			})
 		})
 	})

--- a/types/types.go
+++ b/types/types.go
@@ -69,21 +69,30 @@ type NetConf struct {
 		IPv4Pools  []string `json:"ipv4_pools,omitempty"`
 		IPv6Pools  []string `json:"ipv6_pools,omitempty"`
 	} `json:"ipam,omitempty"`
-	MTU                  int        `json:"mtu"`
-	Hostname             string     `json:"hostname"`
-	Nodename             string     `json:"nodename"`
-	NodenameFileOptional bool       `json:"nodename_file_optional"`
-	DatastoreType        string     `json:"datastore_type"`
-	EtcdAuthority        string     `json:"etcd_authority"`
-	EtcdEndpoints        string     `json:"etcd_endpoints"`
-	LogLevel             string     `json:"log_level"`
-	Policy               Policy     `json:"policy"`
-	Kubernetes           Kubernetes `json:"kubernetes"`
-	Args                 Args       `json:"args"`
-	EtcdScheme           string     `json:"etcd_scheme"`
-	EtcdKeyFile          string     `json:"etcd_key_file"`
-	EtcdCertFile         string     `json:"etcd_cert_file"`
-	EtcdCaCertFile       string     `json:"etcd_ca_cert_file"`
+	Args                 Args              `json:"args"`
+	MTU                  int               `json:"mtu"`
+	Nodename             string            `json:"nodename"`
+	NodenameFileOptional bool              `json:"nodename_file_optional"`
+	DatastoreType        string            `json:"datastore_type"`
+	EtcdEndpoints        string            `json:"etcd_endpoints"`
+	LogLevel             string            `json:"log_level"`
+	Policy               Policy            `json:"policy"`
+	Kubernetes           Kubernetes        `json:"kubernetes"`
+	EtcdScheme           string            `json:"etcd_scheme"`
+	EtcdKeyFile          string            `json:"etcd_key_file"`
+	EtcdCertFile         string            `json:"etcd_cert_file"`
+	EtcdCaCertFile       string            `json:"etcd_ca_cert_file"`
+	ContainerSettings    ContainerSettings `json:"container_settings,omitempty"`
+
+	// Options below here are deprecated.
+	EtcdAuthority string `json:"etcd_authority"`
+	Hostname      string `json:"hostname"`
+}
+
+// ContainerSettings gcontains configuration options
+// to be configured inside the container namespace.
+type ContainerSettings struct {
+	AllowIPForwarding bool `json:"allow_ip_forwarding"`
 }
 
 // CNITestArgs is the CNI_ARGS used for test purposes.


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

https://github.com/projectcalico/cni-plugin/pull/381 broke some users who were relying on this behavior, and we probably shouldn't have changed the default.

This PR makes IP forwarding configurable in the CNI network config.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Add support for configuring container IP forwarding via the CNI configuration file.
```
