### PR TITLE
Disable ipAddrsNoIpam by default

### DIFF
--- a/calico.go
+++ b/calico.go
@@ -191,7 +191,13 @@ func cmdAdd(args *skel.CmdArgs) error {
 			return err
 		}
 	} else {
-		// Default CNI behavior - use the CNI network name as the Calico profile.
+		// Default CNI behavior
+		// Validate enabled features
+		if conf.FeatureControl.IPAddrsNoIpam {
+			return errors.New("requested feature is not supported for this runtime: ip_addrs_no_ipam")
+		}
+
+		// use the CNI network name as the Calico profile.
 		profileID := conf.Name
 
 		endpointAlreadyExisted := endpoint != nil

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -210,6 +210,12 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 			logger.Error(e)
 			return nil, e
 		case ipAddrsNoIpam != "":
+			if !conf.FeatureControl.IPAddrsNoIpam {
+				e := fmt.Errorf("requested feature is not enabled: ip_addrs_no_ipam")
+				logger.Error(e)
+				return nil, e
+			}
+
 			// ipAddrsNoIpam annotation is set so bypass IPAM, and set the IPs manually.
 			overriddenResult, err := overrideIPAMResult(ipAddrsNoIpam, logger)
 			if err != nil {

--- a/types/types.go
+++ b/types/types.go
@@ -30,6 +30,11 @@ type Policy struct {
 	K8sCertificateAuthority string `json:"k8s_certificate_authority"`
 }
 
+// FeatureControl is a struct which controls which features are enabled in Calico.
+type FeatureControl struct {
+	IPAddrsNoIpam bool `json:"ip_addrs_no_ipam"`
+}
+
 // Kubernetes a K8s specific struct to hold config
 type Kubernetes struct {
 	K8sAPIRoot string `json:"k8s_api_root"`
@@ -78,6 +83,7 @@ type NetConf struct {
 	LogLevel             string            `json:"log_level"`
 	Policy               Policy            `json:"policy"`
 	Kubernetes           Kubernetes        `json:"kubernetes"`
+	FeatureControl       FeatureControl    `json:"feature_control"`
 	EtcdScheme           string            `json:"etcd_scheme"`
 	EtcdKeyFile          string            `json:"etcd_key_file"`
 	EtcdCertFile         string            `json:"etcd_cert_file"`


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Add a flag to enable/disable ipAddrsNoIpam. Disable it by default.

The flag is added to the toplevel section of the cni config, in a boolean field called `enable_ip_addrs_no_ipam`.  The CNI spec explicitly allows special fields at this level. I also considered adding a new object field called `calico_features` but wasn't sure there was a strong enough use case for that yet.

## Todos
- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Move ipAddrsNoIpam behind a feature flag in the CNI configuration, and disable it by default. Clusters currently using this feature will need to update their CNI configuration to continue using it when upgrading to this release.
```
