### PR TITLE
Clearly mark deprecated options as deprecated

### DIFF
--- a/calico.go
+++ b/calico.go
@@ -54,6 +54,11 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 	utils.ConfigureLogging(conf.LogLevel)
 
+	// Check for deprecated configuration options and log them out to the user.
+	if err = utils.CheckDeprecation(conf); err != nil {
+		return err
+	}
+
 	if !conf.NodenameFileOptional {
 		// Configured to wait for the nodename file - don't start until it exists.
 		if _, err := os.Stat("/var/lib/calico/nodename"); err != nil {
@@ -318,7 +323,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 
 	// Handle profile creation - this is only done if there isn't a specific policy handler.
-	if conf.Policy.PolicyType == "" {
+	if conf.Policy.PolicyType == "" || conf.Kubernetes.Kubeconfig == "" {
 		logger.Debug("Handling profiles")
 		// Start by checking if the profile already exists. If it already exists then there is no work to do.
 		// The CNI plugin never updates a profile.

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -78,7 +78,7 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 		if err != nil {
 			return nil, err
 		}
-		logger.WithField("client", client).Debug("Created Kubernetes client")
+		logger.WithField("client", client).Debug("Created Kubernetes clientset")
 
 		if conf.IPAM.Type == "host-local" && strings.EqualFold(conf.IPAM.Subnet, "usePodCidr") {
 			// We've been told to use the "host-local" IPAM plugin with the Kubernetes podCidr for this node.
@@ -108,11 +108,9 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 		var ports []api.EndpointPort
 		var profiles []string
 
-		// Only attempt to fetch the labels and annotations from Kubernetes
-		// if the policy type has been set to "k8s". This allows users to
-		// run the plugin under Kubernetes without needing it to access the
-		// Kubernetes API
-		if conf.Policy.PolicyType == "k8s" {
+		// Only attempt to fetch the labels and annotations from Kubernetes if a kubeconfig has been
+		// provided. For compatibility with older configs, also check if the policyType has been set to "k8s".
+		if conf.Policy.PolicyType == "k8s" || conf.Kubernetes.Kubeconfig != "" {
 			var err error
 
 			labels, annot, ports, profiles, err = getK8sPodInfo(client, epIDs.Pod, epIDs.Namespace)

--- a/types/types.go
+++ b/types/types.go
@@ -79,18 +79,18 @@ type NetConf struct {
 	Nodename             string            `json:"nodename"`
 	NodenameFileOptional bool              `json:"nodename_file_optional"`
 	DatastoreType        string            `json:"datastore_type"`
-	EtcdEndpoints        string            `json:"etcd_endpoints"`
 	LogLevel             string            `json:"log_level"`
 	Policy               Policy            `json:"policy"`
 	Kubernetes           Kubernetes        `json:"kubernetes"`
 	FeatureControl       FeatureControl    `json:"feature_control"`
-	EtcdScheme           string            `json:"etcd_scheme"`
+	EtcdEndpoints        string            `json:"etcd_endpoints"`
 	EtcdKeyFile          string            `json:"etcd_key_file"`
 	EtcdCertFile         string            `json:"etcd_cert_file"`
 	EtcdCaCertFile       string            `json:"etcd_ca_cert_file"`
 	ContainerSettings    ContainerSettings `json:"container_settings,omitempty"`
 
 	// Options below here are deprecated.
+	EtcdScheme    string `json:"etcd_scheme"`
 	EtcdAuthority string `json:"etcd_authority"`
 	Hostname      string `json:"hostname"`
 }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

There are a bunch of options we should be marking deprecated in favor of using a kubeconfig file. This PR logs warnings when those options are used.

It also hard errors when `etcd_scheme`, `etcd_authority` or `hostname` are passed in.


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Deprecated CNI config "policy" section. It will be removed in a future relase. Use a kubeconfig file instead.
```

```release-note
The CNI plugin no longer respects the "hostname", "etcd_scheme" and "etcd_authority" configuration options.
```
