### PR TITLE
Tag amd64 builds with latest for CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,6 +261,10 @@ test-watch: $(DIST)/calico $(DIST)/calico-ipam run-etcd run-k8s-apiserver
 
 $(DEPLOY_CONTAINER_MARKER): Dockerfile.$(ARCH) build-containerized fetch-cni-bins
 	docker build -f Dockerfile.$(ARCH) -t $(CONTAINER_NAME):latest-$(ARCH) .
+ifeq ($(ARCH),amd64)
+	# Need amd64 builds tagged as :latest because Semaphore depends on that
+	docker tag $(CONTAINER_NAME):latest-$(ARCH) $(CONTAINER_NAME):latest
+endif
 	touch $@
 
 .PHONY: fetch-cni-bins


### PR DESCRIPTION
## Description

The semaphore job depends on having calico/cni:latest after the build to tag and push to the repos. With a recent change the build only produced calico/cni:latest-amd64 causing the incorrect images to be tagged and pushed.

This change simply tags amd64 builds as `latest` (in addition to the `latest-amd64`).

## Release Note

```release-note
None required
```
