### PR TITLE
Replicate all semaphore activities in ci and cd targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,11 +301,23 @@ test-install-cni: image k8s-install/scripts/install_cni.test
 	cd k8s-install/scripts && CONTAINER_NAME=$(CONTAINER_NAME) ./install_cni.test
 
 ###############################################################################
-# CI
+# CI/CD
 ###############################################################################
 .PHONY: ci
 ## Run what CI runs
 ci: clean static-checks test-cni-versions image test-install-cni
+
+## Deploys images to registry
+cd:
+ifndef CONFIRM
+	$(error CONFIRM is undefined - run using make <target> CONFIRM=true)
+endif
+ifndef BRANCH_NAME
+	$(error BRANCH_NAME is undefined - run using make <target> BRANCH_NAME=var or set an environment variable)
+endif
+	$(MAKE) tag-images push IMAGETAG=${BRANCH_NAME}
+	$(MAKE) tag-images push IMAGETAG=$(shell git describe --tags --dirty --always --long)
+
 
 ###############################################################################
 # Release


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Replicate the workflow from kube-controllers PR here. It already had a `ci` target (which Semaphore already used), so just then `cd` side.

* Create a make cd target that only tags images and pushes to registries

As discussed with @caseydavenport @fasaxc @tomdee



## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```