### PR TITLE
Genname to v31

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -229,11 +229,11 @@ imports:
   subpackages:
   - prometheus
 - name: github.com/prometheus/client_model
-  version: 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
+  version: 6f3806018612930941127f2a7c6c453ba2c527d2
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 7600349dcfe1abd18d72d3a1770870d9800a7801
+  version: e3fb1a1acd7605367a2b378bc2e2f893c05174b7
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
@@ -313,7 +313,7 @@ imports:
   - unicode/norm
   - width
 - name: google.golang.org/appengine
-  version: b1f26356af11148e710935ed1ac8a7f5702c7612
+  version: 0a24098c0ec68416ec050f567f75df563d6b231e
   subpackages:
   - internal
   - internal/app_identity

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: e394ba7842e4c65d984564c39a50cbf31634bd206f980fa3e19d6d3e5c8c2bb2
-updated: 2018-05-29T20:08:22.043311045Z
+updated: 2018-06-08T17:14:28.359062157-07:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -191,7 +191,7 @@ imports:
 - name: github.com/projectcalico/go-yaml-wrapper
   version: 598e54215bee41a19677faa4f0c32acd2a87eb56
 - name: github.com/projectcalico/libcalico-go
-  version: 0417ab6e1ea49be2abb978df365b25f20fdb3c6f
+  version: 19c0325c4b18b526ded50e6a79a0cfb3e449d6e8
   subpackages:
   - lib/apiconfig
   - lib/apis/v1
@@ -253,11 +253,11 @@ imports:
 - name: github.com/spf13/pflag
   version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/vishvananda/netlink
-  version: fe3b5664d23a11b52ba59bece4ff29c52772a56b
+  version: 6e453822d85ef5721799774b654d4d02fed62afb
   subpackages:
   - nl
 - name: github.com/vishvananda/netns
-  version: 8ba1072b58e0c2a240eb5f6120165c7776c3e7b8
+  version: 54f0e4339ce73702a0607f49922aaa1e749b418d
 - name: golang.org/x/crypto
   version: 1351f936d976c60a0a48d728281922cf63eafb8d
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: e394ba7842e4c65d984564c39a50cbf31634bd206f980fa3e19d6d3e5c8c2bb2
-updated: 2018-06-08T17:14:28.359062157-07:00
+hash: ecb13099b2d66417330a5810c990733df64ecc01c81fb77e651cfb4ddbc6d2ff
+updated: 2018-06-08T17:19:05.0405162-07:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -253,7 +253,7 @@ imports:
 - name: github.com/spf13/pflag
   version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/vishvananda/netlink
-  version: 6e453822d85ef5721799774b654d4d02fed62afb
+  version: fe3b5664d23a11b52ba59bece4ff29c52772a56b
   subpackages:
   - nl
 - name: github.com/vishvananda/netns

--- a/glide.yaml
+++ b/glide.yaml
@@ -33,6 +33,7 @@ import:
   - lib/net
   - lib/logutils
 - package: github.com/vishvananda/netlink
+  version: fe3b5664d23a11b52ba59bece4ff29c52772a56b
 - package: k8s.io/client-go
   version: 82aa063804cf055e16e8911250f888bc216e8b61
   subpackages:

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -93,6 +93,7 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 	labels := make(map[string]string)
 	annot := make(map[string]string)
 	var ports []api.EndpointPort
+	var generateName string
 
 	// Only attempt to fetch the labels and annotations from Kubernetes
 	// if the policy type has been set to "k8s". This allows users to
@@ -101,7 +102,7 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 	if conf.Policy.PolicyType == "k8s" {
 		var err error
 
-		labels, annot, ports, err = getK8sPodInfo(client, epIDs.Pod, epIDs.Namespace)
+		labels, annot, ports, generateName, err = getK8sPodInfo(client, epIDs.Pod, epIDs.Namespace)
 		if err != nil {
 			return nil, err
 		}
@@ -242,6 +243,7 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 	endpoint.Name = epIDs.WEPName
 	endpoint.Namespace = epIDs.Namespace
 	endpoint.Labels = labels
+	endpoint.GenerateName = generateName
 	endpoint.Spec.Endpoint = epIDs.Endpoint
 	endpoint.Spec.Node = epIDs.Node
 	endpoint.Spec.Orchestrator = epIDs.Orchestrator
@@ -655,23 +657,24 @@ func newK8sClient(conf types.NetConf, logger *logrus.Entry) (*kubernetes.Clients
 	return kubernetes.NewForConfig(config)
 }
 
-func getK8sPodInfo(client *kubernetes.Clientset, podName, podNamespace string) (labels map[string]string, annotations map[string]string, ports []api.EndpointPort, err error) {
+func getK8sPodInfo(client *kubernetes.Clientset, podName, podNamespace string) (labels map[string]string, annotations map[string]string, ports []api.EndpointPort, generateName string, err error) {
 	pod, err := client.CoreV1().Pods(string(podNamespace)).Get(podName, metav1.GetOptions{})
 	logrus.Infof("pod info %+v", pod)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, "", err
 	}
 
 	var c k8sconversion.Converter
 	kvp, err := c.PodToWorkloadEndpoint(pod)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, "", err
 	}
 
 	ports = kvp.Value.(*api.WorkloadEndpoint).Spec.Ports
 	labels = kvp.Value.(*api.WorkloadEndpoint).Labels
+	generateName = kvp.Value.(*api.WorkloadEndpoint).GenerateName
 
-	return labels, pod.Annotations, ports, nil
+	return labels, pod.Annotations, ports, generateName, nil
 }
 
 func getPodCidr(client *kubernetes.Clientset, conf types.NetConf, nodename string) (string, error) {


### PR DESCRIPTION
## Description
Port the tracking and use of `generateName` metadata to release-v3.1

```release-note
WorkloadEndpoints now include the source Pod's GenerateName
```