### PR TITLE
Exit if the plugin is taking too long

### DIFF
--- a/contrib/test_scripts/netconf/calico-go-with-host-local.json
+++ b/contrib/test_scripts/netconf/calico-go-with-host-local.json
@@ -2,7 +2,7 @@
   "cniVersion": "0.3.1", 			  
   "name": "net1",
   "type": "calico",
-  "log_level": "DEBUG",
+  "log_level": "INFO",
   "etcd_authority": "1.2.3.4:2379",
   "etcd_endpoints": "http://127.0.0.1:2379",
   "ipam": {

--- a/contrib/test_scripts/util.py
+++ b/contrib/test_scripts/util.py
@@ -9,10 +9,10 @@ import sys
 
 NETNS_ROOT = "/var/run/netns/"
 import os
-PLUGIN_LOCATION = os.path.dirname(os.path.realpath(__file__)) + "/../../dist/"
+PLUGIN_LOCATION = os.path.dirname(os.path.realpath(__file__)) + "/../../bin/amd64/"
 def create_container(extra_suffix=""):
     # Generate a random container_id
-    container_id = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
+    container_id = ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(10))
     netnspath = NETNS_ROOT + container_id
     check_call("ip netns add " + container_id, shell=True)
     check_call("ip netns exec %s ip link set lo up " % container_id, shell=True)
@@ -36,7 +36,7 @@ def create_container(extra_suffix=""):
         try:
             output = check_output(extra_suffix+plugin, stdin=f, env=os.environ, shell=True)
             print output
-            ip = json.loads(output)["ip4"]["ip"]
+            ip = json.loads(output)["ips"][0]["address"]
         except CalledProcessError as e:
             print "Plugin call failed"
             print e.output

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -121,11 +121,7 @@ func CleanUpNamespace(args *skel.CmdArgs, logger *logrus.Entry) error {
 					return err
 				})
 
-				if err != nil {
-					ch <- err
-				} else {
-					ch <- nil
-				}
+				ch <- err
 			}()
 
 			select {
@@ -136,7 +132,7 @@ func CleanUpNamespace(args *skel.CmdArgs, logger *logrus.Entry) error {
 					fmt.Fprintf(os.Stderr, "Calico CNI deleted device in netns %s\n", args.Netns)
 				}
 			case <-time.After(5 * time.Second):
-				fmt.Fprintf(os.Stderr, "Calico CNI timed out deleting device in netns %s\n", args.Netns)
+				return fmt.Errorf("Calico CNI timed out deleting device in netns %s", args.Netns)
 			}
 		} else {
 			logger.WithField("ifName", args.IfName).Info("veth does not exist, no need to clean up.")

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/containernetworking/cni/pkg/skel"
 	cnitypes "github.com/containernetworking/cni/pkg/types"

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -111,13 +111,31 @@ func CleanUpNamespace(args *skel.CmdArgs, logger *logrus.Entry) error {
 
 		if devErr == nil {
 			fmt.Fprintf(os.Stderr, "Calico CNI deleting device in netns %s\n", args.Netns)
-			err := ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {
-				_, err := ip.DelLinkByNameAddr(args.IfName, netlink.FAMILY_V4)
-				return err
-			})
+			// Deleting the veth has been seen to hang on some kernel version. Timeout the command if it takes too long.
+			ch := make(chan error, 1)
 
-			if err != nil {
-				return err
+			go func() {
+				err := ns.WithNetNSPath(args.Netns, func(_ ns.NetNS) error {
+					_, err := ip.DelLinkByNameAddr(args.IfName, netlink.FAMILY_V4)
+					return err
+				})
+
+				if err != nil {
+					ch <- err
+				} else {
+					ch <- nil
+				}
+			}()
+
+			select {
+			case err := <-ch:
+				if err != nil {
+					return err
+				} else {
+					fmt.Fprintf(os.Stderr, "Calico CNI deleted device in netns %s\n", args.Netns)
+				}
+			case <-time.After(5 * time.Second):
+				fmt.Fprintf(os.Stderr, "Calico CNI timed out deleting device in netns %s\n", args.Netns)
 			}
 		} else {
 			logger.WithField("ifName", args.IfName).Info("veth does not exist, no need to clean up.")


### PR DESCRIPTION
- [ ] Tests
- [ ] Documentation
- [ ] Release note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Shut down CNI plugin if execution takes over 30 seconds
```

Fixes projectcalico/calico#2098