### PR TITLE
Prompt CNI version to v0.7.1.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ LOCAL_IP_ENV?=$(shell ip route get 8.8.8.8 | head -1 | awk '{print $$7}')
 CURL=curl -sSf
 
 K8S_VERSION?=1.10.4
-CNI_VERSION=v0.6.0
+CNI_VERSION=v0.7.1
 
 # Get version from git.
 GIT_VERSION?=$(shell git describe --tags --dirty)


### PR DESCRIPTION
Due to the hostPort does not work because of issue
https://github.com/containernetworking/plugins/pull/81 , it is
better to upgrade CNI to 0.7.1 to fix this, this can also improve
the portmap performance.

Fixed https://github.com/projectcalico/cni-plugin/issues/585

/cc @caseydavenport 

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Prompt CNI version to v0.7.1.
```
