### PR TITLE
Resolve IP Pool names to CIDRs in IPAM plugin

### DIFF
--- a/ipam/calico-ipam.go
+++ b/ipam/calico-ipam.go
@@ -164,12 +164,12 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 		fmt.Fprintf(os.Stderr, "Calico CNI IPAM request count IPv4=%d IPv6=%d\n", num4, num6)
 
-		v4pools, err := utils.ParsePools(conf.IPAM.IPv4Pools, true)
+		v4pools, err := utils.ResolvePools(ctx, calicoClient, conf.IPAM.IPv4Pools, true)
 		if err != nil {
 			return err
 		}
 
-		v6pools, err := utils.ParsePools(conf.IPAM.IPv6Pools, false)
+		v6pools, err := utils.ResolvePools(ctx, calicoClient, conf.IPAM.IPv6Pools, false)
 		if err != nil {
 			return err
 		}

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -76,7 +76,7 @@ func WipeEtcd() {
 }
 
 // MustCreateNewIPPool creates a new Calico IPAM IP Pool.
-func MustCreateNewIPPool(c client.Interface, cidr string, ipip, natOutgoing, ipam bool) {
+func MustCreateNewIPPool(c client.Interface, cidr string, ipip, natOutgoing, ipam bool) string {
 	log.SetLevel(log.DebugLevel)
 
 	log.SetOutput(os.Stderr)
@@ -102,6 +102,7 @@ func MustCreateNewIPPool(c client.Interface, cidr string, ipip, natOutgoing, ipa
 	if err != nil {
 		panic(err)
 	}
+	return pool.Name
 }
 
 func MustDeleteIPPool(c client.Interface, cidr string) {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -544,6 +544,7 @@ func ResolvePools(ctx context.Context, c client.Interface, pools []string, isv4 
 					if err != nil {
 						return nil, fmt.Errorf("failed to parse IP pool cidr: %s", err)
 					}
+					logrus.Infof("Resolved pool name %s to cidr %s", ipp.Name, cidr)
 				}
 			}
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Support using IP Pool names in the current namespace / pod annotations and CNI config instead of requiring the use of a CIDR explicitly. 

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Support specifying IP Pool by name in CNI config and Kubernetes annotations
```
