### PR TITLE
Disable floating IPs in k8s by default

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -33,6 +33,7 @@ type Policy struct {
 // FeatureControl is a struct which controls which features are enabled in Calico.
 type FeatureControl struct {
 	IPAddrsNoIpam bool `json:"ip_addrs_no_ipam"`
+	FloatingIPs   bool `json:"floating_ips"`
 }
 
 // Kubernetes a K8s specific struct to hold config


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Disable this feature by default, since most users won't need it, and it allows for arbitrary pods to pretend to be other pods.

This feature is new in Calico v3.3.0 (unlreleased) as of this PR: https://github.com/projectcalico/cni-plugin/pull/419

Can be enabled in the CNI config:

```
feature_control: {
  floating_ips: true,
},
```

Corresponding docs: https://github.com/projectcalico/calico/pull/2213

Also added in some releaseIPAM() calls, since we were missing those branches.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
