### PR TITLE
set interfaces.sandbox of CNI result empty

### DIFF
--- a/calico.go
+++ b/calico.go
@@ -319,7 +319,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 		// Add the interface created above to the CNI result.
 		result.Interfaces = append(result.Interfaces, &current.Interface{
-			Name: endpoint.Spec.InterfaceName, Sandbox: endpoint.Spec.Endpoint},
+			Name: endpoint.Spec.InterfaceName},
 		)
 	}
 

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -425,7 +425,7 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 
 	// Add the interface created above to the CNI result.
 	result.Interfaces = append(result.Interfaces, &current.Interface{
-		Name: endpoint.Spec.InterfaceName, Sandbox: endpoint.Spec.Endpoint},
+		Name: endpoint.Spec.InterfaceName},
 	)
 
 	return result, nil


### PR DESCRIPTION
## Description

bug fix
According to  [cni 0.3.0 spec](https://github.com/containernetworking/cni/blob/spec-v0.3.0/SPEC.md) , interfaces.sandbox is required for container/hypervisor interfaces, empty/omitted for host interfaces.

If it's not empty, [bandwidth cni](https://github.com/containernetworking/plugins/tree/master/plugins/meta/bandwidth) will return [error--"no host interface found." ](https://github.com/containernetworking/plugins/blob/master/plugins/meta/bandwidth/main.go#L152) 


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```