### PR TITLE
Remove VOLUME directive from Dockerfiles

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -7,6 +7,5 @@ ADD k8s-install/scripts/install-cni.sh /install-cni.sh
 ADD k8s-install/scripts/calico.conf.default /calico.conf.tmp
 
 ENV PATH=$PATH:/opt/cni/bin
-VOLUME /opt/cni
 WORKDIR /opt/cni/bin
 CMD ["/opt/cni/bin/calico"]

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -7,6 +7,5 @@ ADD k8s-install/scripts/install-cni.sh /install-cni.sh
 ADD k8s-install/scripts/calico.conf.default /calico.conf.tmp
 
 ENV PATH=$PATH:/opt/cni/bin
-VOLUME /opt/cni
 WORKDIR /opt/cni/bin
 CMD ["/opt/cni/bin/calico"]

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -7,6 +7,5 @@ ADD k8s-install/scripts/install-cni.sh /install-cni.sh
 ADD k8s-install/scripts/calico.conf.default /calico.conf.tmp
 
 ENV PATH=$PATH:/opt/cni/bin
-VOLUME /opt/cni
 WORKDIR /opt/cni/bin
 CMD ["/opt/cni/bin/calico"]

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -7,6 +7,5 @@ ADD k8s-install/scripts/install-cni.sh /install-cni.sh
 ADD k8s-install/scripts/calico.conf.default /calico.conf.tmp
 
 ENV PATH=$PATH:/opt/cni/bin
-VOLUME /opt/cni
 WORKDIR /opt/cni/bin
 CMD ["/opt/cni/bin/calico"]


### PR DESCRIPTION
In order to run the image with [Docker No Volume plugin](https://github.com/projectatomic/docker-novolume-plugin) we removed
the VOLUME directive from the Dockerfiles. See #608

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
