### PR TITLE
Use panics instead of log.Fatal

### DIFF
--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -128,7 +128,8 @@ func GetResultForCurrent(session *gexec.Session, cniVersion string) (*current.Re
 		r020 := types020.Result{}
 
 		if err := json.Unmarshal(session.Out.Contents(), &r020); err != nil {
-			log.Fatalf("Error unmarshaling output to Result: %v\n", err)
+			log.Errorf("Error unmarshaling output to Result: %v\n", err)
+			return nil, err
 		}
 
 		rCurrent, err := current.NewResultFromResult(&r020)
@@ -142,7 +143,8 @@ func GetResultForCurrent(session *gexec.Session, cniVersion string) (*current.Re
 	r := current.Result{}
 
 	if err := json.Unmarshal(session.Out.Contents(), &r); err != nil {
-		log.Fatalf("Error unmarshaling output to Result: %v\n", err)
+		log.Errorf("Error unmarshaling output to Result: %v\n", err)
+		return nil, err
 	}
 	return &r, nil
 }
@@ -228,7 +230,8 @@ func RunIPAMPlugin(netconf, command, args, cniVersion string) (*current.Result, 
 		if command == "ADD" {
 			result, err = GetResultForCurrent(session, cniVersion)
 			if err != nil {
-				log.Fatalf("Error getting result from the session: %v \n %v\n", session, err)
+				log.Errorf("Error getting result from the session: %v \n %v\n", session, err)
+				panic(err)
 			}
 		}
 	} else {
@@ -362,7 +365,8 @@ func RunCNIPluginWithId(
 		log.Infof("CNI output: %s", out)
 		r020 := types020.Result{}
 		if err = json.Unmarshal(out, &r020); err != nil {
-			log.Fatalf("Error unmarshaling output to Result: %v\n", err)
+			log.Errorf("Error unmarshaling output to Result: %v\n", err)
+			return
 		}
 
 		result, err = current.NewResultFromResult(&r020)


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

log.Fatal stops the test short and bypasses test reporting. panic gives more logging output and also continues to run tests, simply marking the failed test as errored. 


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
