### PR TITLE
Don't interpret glide WARN as a problem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ update-libcalico:
             if [ $(LIBCALICO_REPO) != "github.com/projectcalico/libcalico-go" ]; then \
               glide mirror set https://github.com/projectcalico/libcalico-go $(LIBCALICO_REPO) --vcs git; glide mirror list; \
             fi;\
-          glide up --strip-vendor; glide up --strip-vendor 2>&1; \
+          glide up --strip-vendor || glide up --strip-vendor; \
         fi'
 
 ## Build the Calico network plugin and ipam plugins

--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,6 @@ update-libcalico:
             fi;\
           OUTPUT=`mktemp`;\
           glide up --strip-vendor; glide up --strip-vendor 2>&1 | grep -v "golang.org/x/sys" | tee $$OUTPUT; \
-          if ! grep "\[WARN\]" $$OUTPUT; then true; else false; fi; \
         fi'
 
 ## Build the Calico network plugin and ipam plugins

--- a/Makefile
+++ b/Makefile
@@ -179,8 +179,7 @@ update-libcalico:
             if [ $(LIBCALICO_REPO) != "github.com/projectcalico/libcalico-go" ]; then \
               glide mirror set https://github.com/projectcalico/libcalico-go $(LIBCALICO_REPO) --vcs git; glide mirror list; \
             fi;\
-          OUTPUT=`mktemp`;\
-          glide up --strip-vendor; glide up --strip-vendor 2>&1 | grep -v "golang.org/x/sys" | tee $$OUTPUT; \
+          glide up --strip-vendor; glide up --strip-vendor 2>&1; \
         fi'
 
 ## Build the Calico network plugin and ipam plugins


### PR DESCRIPTION
Doing so causes our CI and automatic updating to fail unnecessarily.

1. From the perspective of "shall we commit this automatic update or
not", the relevant test is whether "make test" passes following "make
update-libcalico", and the Semaphore triggers already have this logic;
i.e. they only commit and push the glide.yaml and glide.lock changes if
"make test" passes.

2. When the automatic process fails, and I do it manually instead, I've
seen many cases where the glide update emits both WARNs and ERRORs, but
the glide.lock and glide.yaml are as expected and "make test" still
passes anyway.  Hence there are many cases where WARNs and ERRORs are
benign.

3. We can avoid tripping over benign WARNs by removing the extra grep,
as in this commit.  Then the remaining conditions will be (a) that glide
itself completes with successful exit status, and (b) that "make test"
passes following the update.  Which I believe is what we want.

