### PR TITLE
Support DEl on non-existent Azure endpoint

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -205,6 +205,11 @@ func DeleteIPAM(conf types.NetConf, args *skel.CmdArgs, logger *logrus.Entry) er
 		if err := ae.Load(); err != nil {
 			return err
 		}
+		if len(ae.Addresses) == 0 {
+			// If we couldn't find this endpoint, then simply return successfully.
+			logger.WithField("AzureEndpoint", ae).Infof("No endpoint addresses, skip IPAM release")
+			return nil
+		}
 		if err := azure.MutateConfigDel(args, *an, *ae); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

When asked to release an IP for an AzureEndpoint which does not exist, simply return success.

This is modeled after how the Azure plugin handles this case: https://github.com/Azure/azure-container-networking/blob/master/cni/network/network.go#L609-L615

There is a case where the kubelet starts a pod before the CNI plugin can successfully network it. In this case, we'll get a DEL call for a container that does not have an IP assigned, and we need to return successfully.

It's expected CNI plugins will return successfully on DEL calls for things that do not exist. 


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
