### PR TITLE
Add a target to help automate cherry-picks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ install_cni.test
 *.swp
 *.coverprofile
 report/*.xml
+cherry_pick_pull.sh

--- a/Makefile
+++ b/Makefile
@@ -511,6 +511,21 @@ run-kube-proxy:
 	-docker rm -f calico-kube-proxy
 	docker run --name calico-kube-proxy -d --net=host --privileged gcr.io/google_containers/hyperkube:$(K8S_VERSION) /hyperkube proxy --master=http://127.0.0.1:8080 --v=2
 
+## Simple helper for creating a cherry-pick PR. Requires the `hub` CLI tool.
+cherry-pick: cherry-pick-prereqs
+	-@rm -f cherry_pick_pull.sh
+	@wget https://raw.githubusercontent.com/kubernetes/kubernetes/master/hack/cherry_pick_pull.sh && \
+		chmod +x ./cherry_pick_pull.sh && \
+		UPSTREAM_REMOTE=origin ./cherry_pick_pull.sh $(TARGET_BRANCH) $(PR_NUMBER)
+
+cherry-pick-prereqs:
+ifndef TARGET_BRANCH 
+	$(error TARGET_BRANCH must be set)
+endif
+ifndef PR_NUMBER
+	$(error PR_NUMBER must be set)
+endif
+
 .PHONY: test-watch
 ## Run the unit tests, watching for changes.
 test-watch: $(BIN)/calico $(BIN)/calico-ipam run-etcd run-k8s-apiserver


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Wanted to try this out and see what folks thought. Kubernetes has a pretty nice tool for helping create cherry-pick PRs, and it seems to "just work" against Calico repos too!

Trying it as a make target so that we handle the magic of downloading the latest script, removing the need to check it in.

Example:

```
make FORK_REMOTE=cd4 GITHUB_USER=caseydavenport cherry-pick TARGET_BRANCH=release-v3.3 PR_NUMBER=662
```

Here's an example PR created this way: https://github.com/projectcalico/cni-plugin/pull/663


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
