### PR TITLE
Automatic update of GO_BUILD to v0.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ prefix_linux = $(addprefix linux/,$(strip $1))
 join_platforms = $(subst $(space),$(comma),$(call prefix_linux,$(strip $1)))
 
 ###############################################################################
-GO_BUILD_VER ?= v0.17
+GO_BUILD_VER ?= v0.20
 
 SRCFILES=$(shell find pkg cmd internal -name '*.go')
 TEST_SRCFILES=$(shell find tests -name '*.go')

--- a/internal/pkg/utils/network_linux.go
+++ b/internal/pkg/utils/network_linux.go
@@ -432,7 +432,7 @@ func CleanUpNamespace(args *skel.CmdArgs, logger *logrus.Entry) error {
 		})
 
 		if devErr == nil {
-			fmt.Fprintf(os.Stderr, "Calico CNI deleting device in netns %s\n", args.Netns)
+			logger.Infof("Calico CNI deleting device in netns %s", args.Netns)
 			// Deleting the veth has been seen to hang on some kernel version. Timeout the command if it takes too long.
 			ch := make(chan error, 1)
 
@@ -449,7 +449,7 @@ func CleanUpNamespace(args *skel.CmdArgs, logger *logrus.Entry) error {
 				if err != nil {
 					return err
 				} else {
-					fmt.Fprintf(os.Stderr, "Calico CNI deleted device in netns %s\n", args.Netns)
+					logger.Infof("Calico CNI deleted device in netns %s", args.Netns)
 				}
 			case <-time.After(5 * time.Second):
 				return fmt.Errorf("Calico CNI timed out deleting device in netns %s", args.Netns)

--- a/internal/pkg/utils/utils.go
+++ b/internal/pkg/utils/utils.go
@@ -165,7 +165,7 @@ func AddIPAM(conf types.NetConf, args *skel.CmdArgs, logger *logrus.Entry) (*cur
 // It also contains IPAM plugin specific logic based on the configured plugin,
 // and is the logical counterpart to AddIPAM.
 func DeleteIPAM(conf types.NetConf, args *skel.CmdArgs, logger *logrus.Entry) error {
-	fmt.Fprint(os.Stderr, "Calico CNI releasing IP address\n")
+	logger.Info("Calico CNI releasing IP address")
 	logger.WithFields(logrus.Fields{"paths": os.Getenv("CNI_PATH"),
 		"type": conf.IPAM.Type}).Debug("Looking for IPAM plugin in paths")
 
@@ -300,7 +300,7 @@ func replaceHostLocalIPAMPodCIDR(logger *logrus.Entry, rawIpamData interface{}, 
 	}
 	subnet, _ := ipamData["subnet"].(string)
 	if strings.EqualFold(subnet, "usePodCidr") {
-		fmt.Fprint(os.Stderr, "Calico CNI fetching podCidr from Kubernetes\n")
+		logger.Info("Calico CNI fetching podCidr from Kubernetes")
 		podCidr, err := getPodCidr()
 		if err != nil {
 			logger.Info("Failed to getPodCidr")
@@ -308,7 +308,7 @@ func replaceHostLocalIPAMPodCIDR(logger *logrus.Entry, rawIpamData interface{}, 
 		}
 		logger.WithField("podCidr", podCidr).Info("Fetched podCidr")
 		ipamData["subnet"] = podCidr
-		fmt.Fprintf(os.Stderr, "Calico CNI passing podCidr to host-local IPAM: %s\n", podCidr)
+		logger.Infof("Calico CNI passing podCidr to host-local IPAM: %s", podCidr)
 	}
 	return nil
 }

--- a/pkg/ipamplugin/ipam_plugin.go
+++ b/pkg/ipamplugin/ipam_plugin.go
@@ -112,7 +112,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	ctx := context.Background()
 	r := &current.Result{}
 	if ipamArgs.IP != nil {
-		fmt.Fprintf(os.Stderr, "Calico CNI IPAM request IP: %v\n", ipamArgs.IP)
+		logger.Infof("Calico CNI IPAM request IP: %v", ipamArgs.IP)
 
 		// The hostname will be defaulted to the actual hostname if conf.Nodename is empty
 		assignArgs := ipam.AssignIPArgs{
@@ -161,7 +161,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 			num6 = 1
 		}
 
-		fmt.Fprintf(os.Stderr, "Calico CNI IPAM request count IPv4=%d IPv6=%d\n", num4, num6)
+		logger.Infof("Calico CNI IPAM request count IPv4=%d IPv6=%d", num4, num6)
 
 		v4pools, err := utils.ResolvePools(ctx, calicoClient, conf.IPAM.IPv4Pools, true)
 		if err != nil {
@@ -173,7 +173,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 			return err
 		}
 
-		fmt.Fprintf(os.Stderr, "Calico CNI IPAM handle=%s\n", handleID)
+		logger.Infof("Calico CNI IPAM handle=%s", handleID)
 		assignArgs := ipam.AutoAssignArgs{
 			Num4:      num4,
 			Num6:      num6,
@@ -184,7 +184,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		}
 		logger.WithField("assignArgs", assignArgs).Info("Auto assigning IP")
 		assignedV4, assignedV6, err := calicoClient.IPAM().AutoAssign(ctx, assignArgs)
-		fmt.Fprintf(os.Stderr, "Calico CNI IPAM assigned addresses IPv4=%v IPv6=%v\n", assignedV4, assignedV6)
+		logger.Infof("Calico CNI IPAM assigned addresses IPv4=%v IPv6=%v", assignedV4, assignedV6)
 		if err != nil {
 			return err
 		}

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -359,7 +359,7 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 		return nil, err
 	}
 	logger.WithField("endpoint", endpoint).Info("Populated endpoint")
-	fmt.Fprintf(os.Stderr, "Calico CNI using IPs: %s\n", endpoint.Spec.IPNetworks)
+	logger.Infof("Calico CNI using IPs: %s", endpoint.Spec.IPNetworks)
 
 	// releaseIPAM cleans up any IPAM allocations on failure.
 	releaseIPAM := func() {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -284,7 +284,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 			}
 			logger.WithField("endpoint", endpoint).Info("Populated endpoint (with nets)")
 
-			fmt.Fprintf(os.Stderr, "Calico CNI using IPs: %s\n", endpoint.Spec.IPNetworks)
+			logger.Infof("Calico CNI using IPs: %s", endpoint.Spec.IPNetworks)
 
 			// 3) Set up the veth
 			hostVethName, contVethMac, err := utils.DoNetworking(
@@ -344,7 +344,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 			// The profile doesn't exist so needs to be created. The rules vary depending on whether k8s is being used.
 			// Under k8s (without full policy support) the rule is permissive and allows all traffic.
 			// Otherwise, incoming traffic is only allowed from profiles with the same tag.
-			fmt.Fprintf(os.Stderr, "Calico CNI creating profile: %s\n", conf.Name)
+			logger.Infof("Calico CNI creating profile: %s", conf.Name)
 			var inboundRules []api.Rule
 			if wepIDs.Orchestrator == api.OrchestratorKubernetes {
 				inboundRules = []api.Rule{{Action: api.Allow}}


### PR DESCRIPTION
The new linter was complaining about all our `Fprintf` calls, since they return an error, which we ignore.  Might be missing something but I can't see a good reason not to use the logger now it's threaded through the code; I guess the Fprintf output is a bit more "crafted" but at this stage it's mixed in with a lot of log output so maybe better to be consistent and use the logger everywhere?