### PR TITLE
Automated cherry pick of #668: Specify GitHub organization in release-publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -478,7 +478,7 @@ release-publish: release-prereqs
 	# Push binaries to GitHub release.
 	# Requires ghr: https://github.com/tcnksm/ghr
 	# Requires GITHUB_TOKEN environment variable set.
-	ghr -r cni-plugin \
+	ghr -u projectcalico -r cni-plugin \
 		-b "Release notes can be found at https://docs.projectcalico.org" \
 		-n $(VERSION) \
 		$(VERSION) ./bin/github/


### PR DESCRIPTION
Cherry pick of #668 on release-v3.4.

#668: Specify GitHub organization in release-publish