### PR TITLE
calico-ipam-upgrade Implementation

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -6,6 +6,8 @@ imports:
   subpackages:
   - compute/metadata
   - internal
+- name: github.com/alexflint/go-filemutex
+  version: 72bdc8eae2aef913234599b837f5dda445ca9bd9
 - name: github.com/Azure/go-autorest
   version: 1ff28809256a84bb6966640ff3d0371af82ccba4
   subpackages:
@@ -35,6 +37,8 @@ imports:
   - pkg/testutils
   - pkg/utils/hwaddr
   - pkg/utils/sysctl
+  - plugins/ipam/host-local/backend
+  - plugins/ipam/host-local/backend/disk
 - name: github.com/coreos/etcd
   version: 33245c6b5b49130ca99280408fadfab01aac0e48
   subpackages:

--- a/internal/pkg/utils/utils.go
+++ b/internal/pkg/utils/utils.go
@@ -454,15 +454,15 @@ func GetIdentifiers(args *skel.CmdArgs, nodename string) (*WEPIdentifiers, error
 	return &epIDs, nil
 }
 
-func GetHandleID(netName string, containerID string, workload string) (string, error) {
+func GetHandleID(netName, containerID, workload string) string {
 	handleID := fmt.Sprintf("%s.%s", netName, containerID)
 	logrus.WithFields(logrus.Fields{
-		"Network":     netName,
-		"ContainerID": containerID,
-		"Workload":    workload,
 		"HandleID":    handleID,
+		"Network":     netName,
+		"Workload":    workload,
+		"ContainerID": containerID,
 	}).Debug("Generated IPAM handle")
-	return handleID, nil
+	return handleID
 }
 
 func CreateClient(conf types.NetConf) (client.Interface, error) {

--- a/pkg/ipamplugin/ipam_plugin.go
+++ b/pkg/ipamplugin/ipam_plugin.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"time"
 
 	"github.com/containernetworking/cni/pkg/skel"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
@@ -27,6 +28,9 @@ import (
 	cniSpecVersion "github.com/containernetworking/cni/pkg/version"
 	"github.com/projectcalico/cni-plugin/internal/pkg/utils"
 	"github.com/projectcalico/cni-plugin/pkg/types"
+	"github.com/projectcalico/cni-plugin/pkg/upgrade"
+	"github.com/projectcalico/libcalico-go/lib/apiconfig"
+	client "github.com/projectcalico/libcalico-go/lib/clientv3"
 	"github.com/projectcalico/libcalico-go/lib/errors"
 	"github.com/projectcalico/libcalico-go/lib/ipam"
 	"github.com/projectcalico/libcalico-go/lib/logutils"
@@ -46,6 +50,7 @@ func Main(version string) {
 	flagSet := flag.NewFlagSet("calico-ipam", flag.ExitOnError)
 
 	versionFlag := flagSet.Bool("v", false, "Display version")
+	upgradeFlag := flagSet.Bool("upgrade", false, "Upgrade from host-local")
 	err := flagSet.Parse(os.Args[1:])
 
 	if err != nil {
@@ -55,6 +60,42 @@ func Main(version string) {
 
 	if *versionFlag {
 		fmt.Println(version)
+		os.Exit(0)
+	}
+
+	// Migration logic
+	if *upgradeFlag {
+		logrus.Info("migrating from host-local to calico-ipam...")
+		ctxt := context.Background()
+
+		// nodename associates IPs to this node.
+		nodename := os.Getenv("KUBERNETES_NODE_NAME")
+		if nodename == "" {
+			logrus.Fatal("KUBERNETES_NODE_NAME not specified, refusing to migrate...")
+		}
+		logCtxt := logrus.WithField("node", nodename)
+
+		// calicoClient makes IPAM calls.
+		cfg, err := apiconfig.LoadClientConfig("")
+		if err != nil {
+			logCtxt.Fatal("failed to load api client config")
+		}
+		cfg.Spec.DatastoreType = apiconfig.Kubernetes
+		calicoClient, err := client.New(*cfg)
+		if err != nil {
+			logCtxt.Fatal("failed to initialize api client")
+		}
+
+		// Perform the migration.
+		for {
+			err := upgrade.Migrate(ctxt, calicoClient, nodename)
+			if err == nil {
+				break
+			}
+			logCtxt.WithError(err).Error("failed to migrate ipam, retrying...")
+			time.Sleep(time.Second)
+		}
+		logCtxt.Info("migration from host-local to calico-ipam complete")
 		os.Exit(0)
 	}
 
@@ -93,10 +134,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 		return fmt.Errorf("error constructing WorkloadEndpoint name: %s", err)
 	}
 
-	handleID, err := utils.GetHandleID(conf.Name, args.ContainerID, epIDs.WEPName)
-	if err != nil {
-		return err
-	}
+	handleID := utils.GetHandleID(conf.Name, args.ContainerID, epIDs.WEPName)
 
 	logger := logrus.WithFields(logrus.Fields{
 		"Workload":    epIDs.WEPName,
@@ -252,10 +290,7 @@ func cmdDel(args *skel.CmdArgs) error {
 		return fmt.Errorf("error constructing WorkloadEndpoint name: %s", err)
 	}
 
-	handleID, err := utils.GetHandleID(conf.Name, args.ContainerID, epIDs.WEPName)
-	if err != nil {
-		return err
-	}
+	handleID := utils.GetHandleID(conf.Name, args.ContainerID, epIDs.WEPName)
 
 	logger := logrus.WithFields(logrus.Fields{
 		"Workload":    epIDs.WEPName,

--- a/pkg/upgrade/migrate.go
+++ b/pkg/upgrade/migrate.go
@@ -1,0 +1,341 @@
+// Copyright 2015 Tigera Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/containernetworking/plugins/plugins/ipam/host-local/backend/disk"
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	bapi "github.com/projectcalico/libcalico-go/lib/backend/api"
+	"github.com/projectcalico/libcalico-go/lib/backend/k8s"
+	client "github.com/projectcalico/libcalico-go/lib/clientv3"
+	"github.com/projectcalico/libcalico-go/lib/errors"
+	"github.com/projectcalico/libcalico-go/lib/ipam"
+	"github.com/projectcalico/libcalico-go/lib/net"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/projectcalico/libcalico-go/lib/options"
+
+	"github.com/projectcalico/cni-plugin/internal/pkg/utils"
+)
+
+const (
+	ipAllocPath = "/var/lib/cni/networks/k8s-pod-network"
+)
+
+var (
+	binariesToDisable = []string{
+		"/host/opt/cni/bin/calico",
+		"/host/opt/cni/bin/host-local",
+	}
+)
+
+type accessor interface {
+	Backend() bapi.Client
+}
+
+func Migrate(ctxt context.Context, c client.Interface, nodename string) error {
+	// k8sClient directly calls the k8s apiserver.
+	k8sClient := c.(accessor).Backend().(*k8s.KubeClient).ClientSet
+
+	// Check to see if the system is still using host-local
+	// by checking the existence of the path.
+	log.Info("checking host-local IPAM data dir dir existence...")
+	if _, err := os.Stat(ipAllocPath); err != nil && os.IsNotExist(err) {
+		log.Info("host-local IPAM data dir dir not found; no migration necessary, successfully exiting...")
+		return nil
+	}
+
+	// Get node resource to check for IPIP tunnel address.
+	log.Info("retrieving node for IPIP tunnel address")
+	node, err := c.Nodes().Get(ctxt, nodename, options.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get calico node resource: %s", err)
+	}
+
+	// Migrate IPIP tunnel address if the field is empty.
+	if node.Spec.BGP.IPv4IPIPTunnelAddr == "" {
+		log.Info("IPIP tunnel address not found, assigning...")
+
+		// Fetch k8s node.
+		k8sNode, err := k8sClient.CoreV1().Nodes().Get(nodename, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to get k8s node resource: %s", err)
+		}
+
+		// Parse PodCIDR.
+		ip, cidr, err := net.ParseCIDR(k8sNode.Spec.PodCIDR)
+		if err != nil {
+			return fmt.Errorf("PodCIDR %s did not parse successfully: %s", k8sNode.Spec.PodCIDR, err)
+		} else if cidr.Version() == 4 {
+			// We need to get the IP for the podCIDR and increment it to the
+			// first IP in the CIDR.
+			tunIp := ip.To4()
+			if tunIp == nil {
+				return fmt.Errorf("Cannot pick an IPv4 tunnel address from the given CIDR: %s", k8sNode.Spec.PodCIDR)
+			}
+			tunIp[3]++
+			node.Spec.BGP.IPv4IPIPTunnelAddr = tunIp.String()
+
+			// Assign the address via Calico IPAM.
+			ipipTunnelAddr := cnet.ParseIP(node.Spec.BGP.IPv4IPIPTunnelAddr)
+			if err = c.IPAM().AssignIP(ctxt, ipam.AssignIPArgs{
+				IP:       *ipipTunnelAddr,
+				Hostname: nodename,
+				Attrs: map[string]string{
+					"node":           nodename,
+					"ipipTunnelAddr": "true",
+				},
+			}); err != nil {
+				if _, ok := err.(errors.ErrorResourceAlreadyExists); !ok {
+					return fmt.Errorf("failed to get add IPIP tunnel addr %s: %s", node.Spec.BGP.IPv4IPIPTunnelAddr, err)
+				}
+				log.Info("IPIP tunnel address already assigned, continuing...")
+			}
+
+			// Save the calico node object to the datastore.
+			if node, err = c.Nodes().Update(ctxt, node, options.SetOptions{}); err != nil {
+				return fmt.Errorf("failed to save newly updated node object: %s", err)
+			}
+
+			log.Info("Successfully assigned and updated IPIP tunnel address")
+		}
+	}
+	log.WithField("ip", node.Spec.BGP.IPv4IPIPTunnelAddr).Info("node has IPIP tunnel address")
+
+	// Open k8s-pod-directory to check for emptiness.
+	log.Info("checking if host-local IPAM data dir dir is empty...")
+	ipamDir, err := os.Open(ipAllocPath)
+	if err != nil {
+		return fmt.Errorf("failed to open host-local IPAM data dir dir: %s", err)
+	}
+
+	// Check if the directory is empty.
+	if _, err = ipamDir.Readdirnames(1); err != nil {
+		if err == io.EOF {
+			log.Info("host-local IPAM data dir empty; no migration necessary...")
+			log.Info("removing host-local IPAM data directory...")
+			if err = os.Remove(ipAllocPath); err != nil {
+				log.WithError(err).Error("failed to remove host-local IPAM data dir directory")
+			}
+			log.Info("successfully removed host-local IPAM data directory!")
+			return nil
+		}
+		if closeErr := ipamDir.Close(); closeErr != nil {
+			return fmt.Errorf("failed to close host-local IPAM data dir directory on read failure: %s", err)
+		}
+		return fmt.Errorf("failed to read host-local IPAM data dir names: %s", err)
+	}
+	log.Info("host-local IPAM data dir is not empty, migrating...")
+
+	// Close the host-local IPAM data directory file pointer.
+	if closeErr := ipamDir.Close(); closeErr != nil {
+		return fmt.Errorf("failed to close host-local IPAM data dir directory: %s", err)
+	}
+
+	// Disable cni by setting datastoreReady to false.
+	log.Info("setting datastore readiness to false")
+	clusterInfo, err := c.ClusterInformation().Get(ctxt, "default", options.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to fetch cluster information: %s", err)
+	}
+	if *clusterInfo.Spec.DatastoreReady {
+		*clusterInfo.Spec.DatastoreReady = false
+		for i := uint(0); i < 5; i++ {
+			if clusterInfo, err = c.ClusterInformation().Update(ctxt, clusterInfo, options.SetOptions{}); err != nil {
+				if _, ok := err.(errors.ErrorResourceUpdateConflict); ok {
+					log.Info("Encountered update conflict, retrying...")
+					time.Sleep((1 << i) * time.Second)
+				}
+				return fmt.Errorf("failed to disable cluster: %s", err)
+			}
+			break
+		}
+	}
+	log.Info("successfully set datastore readiness to false!")
+
+	// Also disable cni by deleting the binaries.
+	log.Info("removing cni binaries...")
+	for _, binary := range binariesToDisable {
+		if err = os.Remove(binary); err != nil {
+			return fmt.Errorf("failed to remove binary %s: %s", binary, err)
+		}
+		log.WithField("binary", binary).Info("successfully removed cni binary!")
+	}
+	time.Sleep(5 * time.Second)
+
+	// Establishing a mapping of IP addresses to Pods on this node.
+	log.Info("mapping pod ips to pods...")
+	podList, err := k8sClient.CoreV1().Pods("").List(metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodename),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list pods: %s", err)
+	}
+	podIPMap := make(map[string]*corev1.Pod)
+	for i := 0; i < len(podList.Items); i++ {
+		pod := &podList.Items[i]
+		log.WithFields(log.Fields{"pod": pod.Name, "IP": pod.Status.PodIP, "namespace": pod.Namespace}).Info("mapping in pod")
+		podIPMap[pod.Status.PodIP] = pod
+	}
+	log.Info("successfully mapped pod ips to pods!")
+
+	// Acquire a lock on the host-local cni backend
+	log.Info("acquiring lock on host-local backend...")
+	hostLocal, err := disk.New(ipAllocPath, "")
+	if err != nil {
+		return fmt.Errorf("failed to initialize host local backend: %s", err)
+	}
+	if err = hostLocal.Lock(); err != nil {
+		return fmt.Errorf("failed to acquire lock on host local backend: %s", err)
+	}
+	log.Info("successfully acquired lock on host-local backend!")
+	defer func() {
+		// Release the lock on host local backend
+		log.Info("releasing lock on host-local backend...")
+		if err = hostLocal.Unlock(); err != nil {
+			log.WithError(err).Error("failed to release lock on host local backend")
+		}
+		log.Info("successfully released lock on host-local backend!")
+	}()
+
+	// Read in all the files in the host-local directory.
+	log.Info("reading files from host-local IPAM data dir...")
+	files, err := ioutil.ReadDir(ipAllocPath)
+	if err != nil {
+		return fmt.Errorf("failed to read path %s: %s", ipAllocPath, err)
+	}
+
+	// For each file, convert it into an IP allocation and then delete the file.
+	for _, f := range files {
+		logCtxt := log.WithField("file", f.Name())
+		logCtxt.Info("processing file...")
+		fname := path.Join(ipAllocPath, f.Name())
+
+		// Delete and skip the last reserved IP.
+		if strings.Contains(f.Name(), "last") {
+			logCtxt.Info("skipping and removing last reserved ip file...")
+			if err = os.Remove(fname); err != nil {
+				return fmt.Errorf("failed to remove file %s: %s", fname, err)
+			}
+			logCtxt.Info("successfully removed last reserved ip file!")
+			continue
+		}
+
+		// Skip the lock
+		if f.Name() == "lock" {
+			logCtxt.Info("skipping the lock...")
+			continue
+		}
+
+		// The name of the file is its IP address.
+		ip, _, err := cnet.ParseCIDR(fmt.Sprintf("%s/32", f.Name()))
+		if err != nil {
+			return fmt.Errorf("failed to parse IP %s: %s", f.Name(), err)
+		}
+
+		// The contents are the container ID.
+		b, err := ioutil.ReadFile(fname)
+		if err != nil {
+			return fmt.Errorf("failed to read file %s: %s", fname, err)
+		}
+		containerID := string(b)
+
+		// See if the IP hasn't already been assigned for the handleID.
+		handleID := utils.GetHandleID("k8s-pod-network", containerID, "")
+		ips, err := c.IPAM().IPsByHandle(ctxt, handleID)
+		if err == nil {
+		} else if _, ok := err.(errors.ErrorResourceDoesNotExist); !ok {
+			// Return error if it is NOT does not exist, otherwise continue.
+			return fmt.Errorf("failed to fetch ips for handleID %s: %s", handleID, err)
+		}
+		logCtxt.WithField("handleID", handleID).Info("file contains handle ID")
+
+		alreadyExists := false
+		for _, ip := range ips {
+			if _, ok := podIPMap[ip.String()]; ok {
+				alreadyExists = true
+				break
+			}
+		}
+		if alreadyExists {
+			logCtxt.Info("pod IP already assigned, skipping...")
+			continue
+		}
+
+		// Get the pod resource associated with the IP.
+		pod, ok := podIPMap[f.Name()]
+		if !ok {
+			logCtxt.WithField("ip", f.Name()).Info("pod not found for IP, deleting and continuing...")
+			if err = os.Remove(fname); err != nil {
+				return fmt.Errorf("failed to remove file %s: %s", fname, err)
+			}
+			continue
+		}
+
+		// Store allocation to datastore
+		logCtxt.Info("assinging pod IP to Calico IPAM...")
+		if err = c.IPAM().AssignIP(ctxt, ipam.AssignIPArgs{
+			IP:       *ip,
+			HandleID: &handleID,
+			Hostname: nodename,
+			Attrs: map[string]string{
+				ipam.AttributeNode:      nodename,
+				ipam.AttributePod:       pod.Name,
+				ipam.AttributeNamespace: pod.Namespace,
+			},
+		}); err != nil {
+			return fmt.Errorf("failed to assign IP to calico backend: %s", err)
+		}
+		logCtxt.Info("successfully assinged pod IP to Calico IPAM...")
+
+		// Delete the file
+		logCtxt.Info("removing file...")
+		if err = os.Remove(fname); err != nil {
+			return fmt.Errorf("failed to remove file %s: %s", fname, err)
+		}
+		logCtxt.Info("successfully removed file!")
+	}
+
+	// Delete the host-local IPAM data directory
+	log.Info("removing host-local IPAM data directory...")
+	if err = os.Remove(ipAllocPath); err != nil {
+		log.WithError(err).Error("failed to remove host-local IPAM data dir directory")
+	}
+	log.Info("successfully removed host-local IPAM data directory!")
+
+	// HACK: Always re-enable datastoreReady.
+	// TODO: Should check DaemonSet rolling update status to see if this is the last node to update and
+	// only re-enable datastoreReady if the number of UpdatedNumberScheduled is MaxUnavailable less than the DesiredNumberScheduled.
+	// calicoDS, err := k8sClient.AppsV1().DaemonSets("kube-system").Get("calico-node", metav1.GetOptions{})
+	// if (calicoDS.Status.UpdatedNumberScheduled == calicoDS.Status.DesiredNumberScheduled-calicoDS.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable.IntVal)
+	log.Info("setting Calico datastore readiness to true...")
+	*clusterInfo.Spec.DatastoreReady = true
+	if _, err = c.ClusterInformation().Update(ctxt, clusterInfo, options.SetOptions{}); err != nil {
+		return fmt.Errorf("failed to re-enable cluster: %s", err)
+	}
+	log.Info("successfully set Calico datastore readiness to true!")
+
+	return nil
+}

--- a/tests/calico_cni_k8s_test.go
+++ b/tests/calico_cni_k8s_test.go
@@ -1928,7 +1928,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 
 		checkIPAMReservation := func() {
 			// IPAM reservation should still be in place.
-			handleID, _ := utils.GetHandleID("calico-uts", containerID, workloadName)
+			handleID := utils.GetHandleID("calico-uts", containerID, workloadName)
 			ipamIPs, err := calicoClient.IPAM().IPsByHandle(context.Background(), handleID)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "error getting IPs")
 			ExpectWithOffset(1, ipamIPs).To(HaveLen(1),

--- a/tests/calico_cni_test.go
+++ b/tests/calico_cni_test.go
@@ -567,7 +567,7 @@ var _ = Describe("CalicoCni", func() {
 
 		checkIPAMReservation := func() {
 			// IPAM reservation should still be in place.
-			handleID, _ := utils.GetHandleID("net1", containerID, workloadName)
+			handleID := utils.GetHandleID("net1", containerID, workloadName)
 			ipamIPs, err := calicoClient.IPAM().IPsByHandle(context.Background(), handleID)
 			ExpectWithOffset(1, err).NotTo(HaveOccurred())
 			ExpectWithOffset(1, ipamIPs).To(HaveLen(1),


### PR DESCRIPTION
## Description
- adds a new binary `calico-ipam-upgrade` for migrating the data necessary to upgrade KDD-backed calico installations from using host-local IPAM to Calico IPAM

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note
