### PR TITLE
Automated cherry pick of #713: Rev CNI version to 0.7.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ LOCAL_IP_ENV?=$(shell ip route get 8.8.8.8 | head -1 | awk '{print $$7}')
 CURL=curl -sSf
 
 K8S_VERSION?=v1.11.3
-CNI_VERSION=v0.7.1
+CNI_VERSION=v0.7.5
 
 # Get version from git.
 GIT_VERSION:=$(shell git describe --tags --dirty --always)


### PR DESCRIPTION
Cherry pick of #713 on release-v3.6.

#713: Rev CNI version to 0.7.5

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Update to CNI plugins v0.7.5
```