### PR TITLE
adding fixed IPs for Mesos like k8s annotations

### DIFF
--- a/pkg/cni_default/cni_default.go
+++ b/pkg/cni_default/cni_default.go
@@ -1,0 +1,294 @@
+// Copyright 2015 Tigera Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cni_default
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/projectcalico/cni-plugin/internal/pkg/utils"
+	"github.com/projectcalico/cni-plugin/pkg/types"
+	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
+	calicoclient "github.com/projectcalico/libcalico-go/lib/clientv3"
+	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
+	"github.com/projectcalico/libcalico-go/lib/options"
+	"github.com/sirupsen/logrus"
+)
+
+// CmdAddCNIDefault performs the "ADD" operation with default CNI logic
+
+func CmdAddCNIDefault(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epIDs utils.WEPIdentifiers, calicoClient calicoclient.Interface, endpoint *api.WorkloadEndpoint) (*current.Result, error) {
+	var err error
+	var result *current.Result
+
+	//// Validate enabled features
+	// this is checked is ProcessIpAddrs for both k8s and default versions of plugins
+
+	//if conf.FeatureControl.IPAddrsNoIpam {
+	//	return nil, errors.New("requested feature is not supported for this runtime: ip_addrs_no_ipam")
+	//}
+
+	logger := logrus.WithFields(logrus.Fields{
+		"ContainerID": epIDs.ContainerID,
+	})
+
+	// use the CNI network name as the Calico profile.
+	profileID := conf.Name
+
+	endpointAlreadyExisted := endpoint != nil
+	if endpointAlreadyExisted {
+		// There is an existing endpoint - no need to create another.
+		// This occurs when adding an existing container to a new CNI network
+		// Find the IP address from the endpoint and use that in the response.
+		// Don't create the veth or do any networking.
+		// Just update the profile on the endpoint. The profile will be created if needed during the
+		// profile processing step.
+		foundProfile := false
+		for _, p := range endpoint.Spec.Profiles {
+			if p == profileID {
+				logger.Infof("Calico CNI endpoint already has profile: %s\n", profileID)
+				foundProfile = true
+				break
+			}
+		}
+		if !foundProfile {
+			logger.Infof("Calico CNI appending profile: %s\n", profileID)
+			endpoint.Spec.Profiles = append(endpoint.Spec.Profiles, profileID)
+		}
+		result, err = utils.CreateResultFromEndpoint(endpoint)
+		logger.WithField("result", result).Debug("Created result from endpoint")
+		if err != nil {
+			return nil, err
+		}
+	} else {
+
+		// There's no existing endpoint, so we need to do the following:
+		// 1) Call the configured IPAM plugin to get IP address(es)
+		// 2) Configure the Calico endpoint
+		// 3) Create the veth, configuring it on both the host and container namespace.
+
+		// Parse endpoint labels passed in by Mesos, and store in a map.
+		labels := map[string]string{}
+		for _, label := range conf.Args.Mesos.NetworkInfo.Labels.Labels {
+			// Sanitize mesos labels so that they pass the k8s label validation,
+			// as mesos labels accept any unicode value.
+			k := utils.SanitizeMesosLabel(label.Key)
+			v := utils.SanitizeMesosLabel(label.Value)
+
+			labels[k] = v
+		}
+
+
+		originalLabels := map[string]string{}
+		for _, originalLabel := range conf.Args.Mesos.NetworkInfo.Labels.Labels {
+			k := originalLabel.Key
+			v := originalLabel.Value
+
+			originalLabels[k] = v
+		}
+
+		//ipAddrsNoIpam := annot["cni.projectcalico.org/ipAddrsNoIpam"]
+		//ipAddrs := annot["cni.projectcalico.org/ipAddrs"]
+		ipAddrs := originalLabels["cni.projectcalico.org/ipAddrs"]
+		ipAddrsNoIpam := originalLabels["cni.projectcalico.org/ipAddrsNoIpam"]
+
+
+		logger.Debugf("originalLabels %v, ipAddrs %s, ipAddrsNoIpam %s", originalLabels, ipAddrs, ipAddrsNoIpam)
+
+		result, err = ProcessIpAddrs(ipAddrs, ipAddrsNoIpam, conf, args, logger, calicoClient, endpoint)
+		if err != nil {
+			return nil, err
+		}
+
+		// 1) Run the IPAM plugin and make sure there's an IP address returned.
+		// see ProcessIpAddrs switch case ipAddrs == "" && ipAddrsNoIpam == "":
+
+
+		// 2) Create the endpoint object
+		endpoint = api.NewWorkloadEndpoint()
+		endpoint.Name = epIDs.WEPName
+		endpoint.Namespace = epIDs.Namespace
+		endpoint.Spec.Endpoint = epIDs.Endpoint
+		endpoint.Spec.Node = epIDs.Node
+		endpoint.Spec.Orchestrator = epIDs.Orchestrator
+		endpoint.Spec.ContainerID = epIDs.ContainerID
+		endpoint.Labels = labels
+		endpoint.Spec.Profiles = []string{profileID}
+
+		logger.WithField("endpoint", endpoint).Debug("Populated endpoint (without nets)")
+		if err = utils.PopulateEndpointNets(endpoint, result); err != nil {
+			// Cleanup IP allocation and return the error.
+			utils.ReleaseIPAllocation(logger, conf, args)
+			return nil, err
+		}
+		logger.WithField("endpoint", endpoint).Info("Populated endpoint (with nets)")
+
+		logger.Infof("Calico CNI using IPs: %s", endpoint.Spec.IPNetworks)
+
+		// 3) Set up the veth
+		hostVethName, contVethMac, err := utils.DoNetworking(
+			args, conf, result, logger, "", utils.DefaultRoutes)
+		if err != nil {
+			// Cleanup IP allocation and return the error.
+			utils.ReleaseIPAllocation(logger, conf, args)
+			return nil, err
+		}
+
+		logger.WithFields(logrus.Fields{
+			"HostVethName":     hostVethName,
+			"ContainerVethMac": contVethMac,
+		}).Info("Networked namespace")
+
+		endpoint.Spec.MAC = contVethMac
+		endpoint.Spec.InterfaceName = hostVethName
+	}
+
+	// Write the endpoint object (either the newly created one, or the updated one with a new ProfileIDs).
+	if _, err := utils.CreateOrUpdate(ctx, calicoClient, endpoint); err != nil {
+		if !endpointAlreadyExisted {
+			// Only clean up the IP allocation if this was a new endpoint.  Otherwise,
+			// we'd release the IP that is already attached to the existing endpoint.
+			utils.ReleaseIPAllocation(logger, conf, args)
+		}
+		return nil, err
+	}
+
+	logger.WithField("endpoint", endpoint).Info("Wrote endpoint to datastore")
+
+	// Add the interface created above to the CNI result.
+	result.Interfaces = append(result.Interfaces, &current.Interface{
+		Name: endpoint.Spec.InterfaceName},
+	)
+	return result, nil
+}
+
+
+
+func ProcessIpAddrs(ipAddrs string, ipAddrsNoIpam string, conf types.NetConf, args *skel.CmdArgs, logger *logrus.Entry, calicoClient calicoclient.Interface, endpoint *api.WorkloadEndpoint) (*current.Result, error){
+	var err error
+	var result *current.Result
+
+	// Switch based on which annotations are passed or not passed.
+	switch {
+	case ipAddrs == "" && ipAddrsNoIpam == "":
+		// Call the IPAM plugin.
+		result, err = utils.AddIPAM(conf, args, logger)
+		if err != nil {
+			return nil, err
+		}
+
+	case ipAddrs != "" && ipAddrsNoIpam != "":
+		// Can't have both ipAddrs and ipAddrsNoIpam annotations at the same time.
+		e := fmt.Errorf("can't have both annotations: 'ipAddrs' and 'ipAddrsNoIpam' in use at the same time")
+		logger.Error(e)
+		return nil, e
+
+	case ipAddrsNoIpam != "":
+		// Validate that we're allowed to use this feature.
+		if conf.IPAM.Type != "calico-ipam" {
+			e := fmt.Errorf("ipAddrsNoIpam is not compatible with configured IPAM: %s", conf.IPAM.Type)
+			logger.Error(e)
+			return nil, e
+		}
+
+		if !conf.FeatureControl.IPAddrsNoIpam {
+			e := fmt.Errorf("requested feature is not enabled: ip_addrs_no_ipam")
+			logger.Error(e)
+			return nil, e
+		}
+
+		// ipAddrsNoIpam annotation is set so bypass IPAM, and set the IPs manually.
+		overriddenResult, err := overrideIPAMResult(ipAddrsNoIpam, logger)
+		if err != nil {
+			return nil, err
+		}
+		logger.Debugf("Bypassing IPAM to set the result to: %+v", overriddenResult)
+
+		// Convert overridden IPAM result into current Result.
+		// This method fill in all the empty fields necessory for CNI output according to spec.
+		result, err = current.NewResultFromResult(overriddenResult)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(result.IPs) == 0 {
+			return nil, errors.New("failed to build result")
+		}
+
+	case ipAddrs != "":
+		// Validate that we're allowed to use this feature.
+		if conf.IPAM.Type != "calico-ipam" {
+			e := fmt.Errorf("ipAddrs is not compatible with configured IPAM: %s", conf.IPAM.Type)
+			logger.Error(e)
+			return nil, e
+		}
+
+		// If the endpoint already exists, we need to attempt to release the previous IP addresses here
+		// since the ADD call will fail when it tries to reallocate the same IPs. releaseIPAddrs assumes
+		// that Calico IPAM is in use, which is OK here since only Calico IPAM supports the ipAddrs
+		// annotation.
+		if endpoint != nil {
+			logger.Info("Endpoint already exists and ipAddrs is set. Release any old IPs")
+			if err := releaseIPAddrs(endpoint.Spec.IPNetworks, calicoClient, logger); err != nil {
+				return nil, fmt.Errorf("failed to release ipAddrs: %s", err)
+			}
+		}
+
+		// When ipAddrs annotation is set, we call out to the configured IPAM plugin
+		// requesting the specific IP addresses included in the annotation.
+		result, err = ipAddrsResult(ipAddrs, conf, args, logger)
+		if err != nil {
+			return nil, err
+		}
+		logger.Debugf("IPAM result set to: %+v", result)
+	}
+
+	return result, nil
+}
+
+
+// CmdDelK8s performs CNI DEL processing when running under Kubernetes. In Kubernetes, we identify workload endpoints based on their
+// pod name and namespace rather than container ID, so we may receive multiple DEL calls for the same pod, but with different container IDs.
+// As such, we must only delete the workload endpoint when the provided CNI_CONATAINERID matches the value on the WorkloadEndpoint. If they do not match,
+// it means the DEL is for an old sandbox and the pod is still running. We should still clean up IPAM allocations, since they are identified by the
+// container ID rather than the pod name and namespace. If they do match, then we can delete the workload endpoint.
+func CmdDelCNIDefault(ctx context.Context, calicoClient calicoclient.Interface, epIDs utils.WEPIdentifiers, args *skel.CmdArgs, conf types.NetConf, logger *logrus.Entry) error {
+	// Release the IP address by calling the configured IPAM plugin.
+	ipamErr := utils.DeleteIPAM(conf, args, logger)
+
+	var err error
+	// Delete the WorkloadEndpoint object from the datastore.
+
+	if _, err = calicoClient.WorkloadEndpoints().Delete(ctx, epIDs.Namespace, epIDs.WEPName, options.DeleteOptions{}); err != nil {
+		if _, ok := err.(cerrors.ErrorResourceDoesNotExist); ok {
+			// Log and proceed with the clean up if WEP doesn't exist.
+			logger.WithField("WorkloadEndpoint", epIDs.WEPName).Info("Endpoint object does not exist, no need to clean up.")
+		} else {
+			return err
+		}
+	}
+
+	// Clean up namespace by removing the interfaces.
+	err = utils.CleanUpNamespace(args, logger)
+	if err != nil {
+		return err
+	}
+
+	// Return the IPAM error if there was one. The IPAM error will be lost if there was also an error in cleaning up
+	// the device or endpoint, but crucially, the user will know the overall operation failed.
+	return ipamErr
+}

--- a/pkg/cni_default/helpers.go
+++ b/pkg/cni_default/helpers.go
@@ -1,0 +1,268 @@
+// Copyright 2015 Tigera Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cni_default
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/containernetworking/cni/pkg/skel"
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/containernetworking/plugins/pkg/ipam"
+	"github.com/projectcalico/cni-plugin/internal/pkg/utils"
+	"github.com/projectcalico/cni-plugin/pkg/types"
+	calicoclient "github.com/projectcalico/libcalico-go/lib/clientv3"
+	cnet "github.com/projectcalico/libcalico-go/lib/net"
+	"github.com/sirupsen/logrus"
+	"net"
+	"os"
+)
+// ipAddrsResult parses the ipAddrs annotation and calls the configured IPAM plugin for
+// each IP passed to it by setting the IP field in CNI_ARGS, and returns the result of calling the IPAM plugin.
+// Example annotation value string: "[\"10.0.0.1\", \"2001:db8::1\"]"
+func ipAddrsResult(ipAddrs string, conf types.NetConf, args *skel.CmdArgs, logger *logrus.Entry) (*current.Result, error) {
+	logger.Infof("Parsing annotation \"cni.projectcalico.org/ipAddrs\":%s", ipAddrs)
+
+	// We need to make sure there is only one IPv4 and/or one IPv6
+	// passed in, since CNI spec only supports one of each right now.
+	ipList, err := validateAndExtractIPs(ipAddrs, "cni.projectcalico.org/ipAddrs", logger)
+	if err != nil {
+		return nil, err
+	}
+
+	result := current.Result{}
+
+	// Go through all the IPs passed in as annotation value and call IPAM plugin
+	// for each, and populate the result variable with IP4 and/or IP6 IPs returned
+	// from the IPAM plugin.
+	for _, ip := range ipList {
+		// Call callIPAMWithIP with the ip address.
+		r, err := callIPAMWithIP(ip, conf, args, logger)
+		if err != nil {
+			return nil, fmt.Errorf("error getting IP from IPAM: %s", err)
+		}
+
+		result.IPs = append(result.IPs, r.IPs[0])
+		logger.Debugf("Adding IPv%s: %s to result", r.IPs[0].Version, ip.String())
+	}
+
+	return &result, nil
+}
+
+// callIPAMWithIP sets CNI_ARGS with the IP and calls the IPAM plugin with it
+// to get current.Result and then it unsets the IP field from CNI_ARGS ENV var,
+// so it doesn't pollute the subsequent requests.
+func callIPAMWithIP(ip net.IP, conf types.NetConf, args *skel.CmdArgs, logger *logrus.Entry) (*current.Result, error) {
+
+	// Save the original value of the CNI_ARGS ENV var for backup.
+	originalArgs := os.Getenv("CNI_ARGS")
+	logger.Debugf("Original CNI_ARGS=%s", originalArgs)
+
+	ipamArgs := struct {
+		cnitypes.CommonArgs
+		IP net.IP `json:"ip,omitempty"`
+	}{}
+
+	if err := cnitypes.LoadArgs(args.Args, &ipamArgs); err != nil {
+		return nil, err
+	}
+
+	if ipamArgs.IP != nil {
+		logger.Errorf("'IP' variable already set in CNI_ARGS environment variable.")
+	}
+
+	// Request the provided IP address using the IP CNI_ARG.
+	// See: https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md#cni_args for more info.
+	newArgs := originalArgs + ";IP=" + ip.String()
+	logger.Debugf("New CNI_ARGS=%s", newArgs)
+
+	// Set CNI_ARGS to the new value.
+	err := os.Setenv("CNI_ARGS", newArgs)
+	if err != nil {
+		return nil, fmt.Errorf("error setting CNI_ARGS environment variable: %v", err)
+	}
+
+	// Run the IPAM plugin.
+	logger.Debugf("Calling IPAM plugin %s", conf.IPAM.Type)
+	r, err := ipam.ExecAdd(conf.IPAM.Type, args.StdinData)
+	if err != nil {
+		// Restore the CNI_ARGS ENV var to it's original value,
+		// so the subsequent calls don't get polluted by the old IP value.
+		if err := os.Setenv("CNI_ARGS", originalArgs); err != nil {
+			logger.Errorf("Error setting CNI_ARGS environment variable: %v", err)
+		}
+		return nil, err
+	}
+	logger.Debugf("IPAM plugin returned: %+v", r)
+
+	// Restore the CNI_ARGS ENV var to it's original value,
+	// so the subsequent calls don't get polluted by the old IP value.
+	if err := os.Setenv("CNI_ARGS", originalArgs); err != nil {
+		// Need to clean up IP allocation if this step doesn't succeed.
+		utils.ReleaseIPAllocation(logger, conf, args)
+		logger.Errorf("Error setting CNI_ARGS environment variable: %v", err)
+		return nil, err
+	}
+
+	// Convert IPAM result into current Result.
+	// IPAM result has a bunch of fields that are optional for an IPAM plugin
+	// but required for a CNI plugin, so this is to populate those fields.
+	// See CNI Spec doc for more details.
+	ipamResult, err := current.NewResultFromResult(r)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(ipamResult.IPs) == 0 {
+		return nil, errors.New("IPAM plugin returned missing IP config")
+	}
+
+	return ipamResult, nil
+}
+
+// overrideIPAMResult generates current.Result like the one produced by IPAM plugin,
+// but sets IP field manually since IPAM is bypassed with this annotation.
+// Example annotation value string: "[\"10.0.0.1\", \"2001:db8::1\"]"
+func overrideIPAMResult(ipAddrsNoIpam string, logger *logrus.Entry) (*current.Result, error) {
+	logger.Infof("Parsing annotation \"cni.projectcalico.org/ipAddrsNoIpam\":%s", ipAddrsNoIpam)
+
+	// We need to make sure there is only one IPv4 and/or one IPv6
+	// passed in, since CNI spec only supports one of each right now.
+	ipList, err := validateAndExtractIPs(ipAddrsNoIpam, "cni.projectcalico.org/ipAddrsNoIpam", logger)
+	if err != nil {
+		return nil, err
+	}
+
+	result := current.Result{}
+
+	// Go through all the IPs passed in as annotation value and populate
+	// the result variable with IP4 and/or IP6 IPs.
+	for _, ip := range ipList {
+		var version string
+		var mask net.IPMask
+
+		if ip.To4() != nil {
+			version = "4"
+			mask = net.CIDRMask(32, 32)
+
+		} else {
+			version = "6"
+			mask = net.CIDRMask(128, 128)
+		}
+
+		ipConf := &current.IPConfig{
+			Version: version,
+			Address: net.IPNet{
+				IP:   ip,
+				Mask: mask,
+			},
+		}
+		result.IPs = append(result.IPs, ipConf)
+		logger.Debugf("Adding IPv%s: %s to result", ipConf.Version, ip.String())
+	}
+
+	return &result, nil
+}
+
+// validateAndExtractIPs is a utility function that validates the passed IP list to make sure
+// there is one IPv4 and/or one IPv6 and then returns the slice of IPs.
+func validateAndExtractIPs(ipAddrs string, annotation string, logger *logrus.Entry) ([]net.IP, error) {
+	// Parse IPs from JSON.
+	ips, err := ParseIPAddrs(ipAddrs, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse IPs %s for annotation \"%s\": %s", ipAddrs, annotation, err)
+	}
+
+	// annotation value can't be empty.
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("annotation \"%s\" specified but empty", annotation)
+	}
+
+	var hasIPv4, hasIPv6 bool
+	var ipList []net.IP
+
+	// We need to make sure there is only one IPv4 and/or one IPv6
+	// passed in, since CNI spec only supports one of each right now.
+	for _, ip := range ips {
+		ipAddr := net.ParseIP(ip)
+		if ipAddr == nil {
+			logger.WithField("IP", ip).Error("Invalid IP format")
+			return nil, fmt.Errorf("invalid IP format: %s", ip)
+		}
+
+		if ipAddr.To4() != nil {
+			if hasIPv4 {
+				// Check if there is already has been an IPv4 in the list, as we only support one IPv4 and/or one IPv6 per interface for now.
+				return nil, fmt.Errorf("cannot have more than one IPv4 address for \"%s\" annotation", annotation)
+			}
+			hasIPv4 = true
+		} else {
+			if hasIPv6 {
+				// Check if there is already has been an IPv6 in the list, as we only support one IPv4 and/or one IPv6 per interface for now.
+				return nil, fmt.Errorf("cannot have more than one IPv6 address for \"%s\" annotation", annotation)
+			}
+			hasIPv6 = true
+		}
+
+		// Append the IP to ipList slice.
+		ipList = append(ipList, ipAddr)
+	}
+
+	return ipList, nil
+}
+
+// ParseIPAddrs is a utility function that parses string of IPs in json format that are
+// passed in as a string and returns a slice of string with IPs.
+// It also makes sure the slice isn't empty.
+func ParseIPAddrs(ipAddrsStr string, logger *logrus.Entry) ([]string, error) {
+	var ips []string
+
+	err := json.Unmarshal([]byte(ipAddrsStr), &ips)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse '%s' as JSON: %s", ipAddrsStr, err)
+	}
+
+	logger.Debugf("IPs parsed: %v", ips)
+
+	return ips, nil
+}
+
+// releaseIPAddrs calls directly into Calico IPAM to release the specified IP addresses.
+// NOTE: This function assumes Calico IPAM is in use, and calls into it directly rather than calling the IPAM plugin.
+func releaseIPAddrs(ipAddrs []string, calico calicoclient.Interface, logger *logrus.Entry) error {
+	// For each IP, call out to Calico IPAM to release it.
+	for _, ip := range ipAddrs {
+		log := logger.WithField("IP", ip)
+		log.Info("Releasing explicitly requested address")
+		cip, _, err := cnet.ParseCIDR(ip)
+		if err != nil {
+			return err
+		}
+		unallocated, err := calico.IPAM().ReleaseIPs(context.Background(), []cnet.IP{*cip})
+		if err != nil {
+			log.WithError(err).Error("Failed to release explicit IP")
+			return err
+		}
+		if len(unallocated) > 0 {
+			log.Warn("Asked to release address but it doesn't exist.")
+		} else {
+			log.Infof("Released explicit address: %s", ip)
+		}
+	}
+	return nil
+}
+

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -17,23 +17,20 @@ package k8s
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
+	"github.com/projectcalico/cni-plugin/pkg/cni_default"
 	"net"
 	"os"
 	"strings"
 
 	"github.com/containernetworking/cni/pkg/skel"
-	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
-	"github.com/containernetworking/plugins/pkg/ipam"
 	"github.com/projectcalico/cni-plugin/internal/pkg/utils"
 	"github.com/projectcalico/cni-plugin/pkg/types"
 	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	k8sconversion "github.com/projectcalico/libcalico-go/lib/backend/k8s/conversion"
 	calicoclient "github.com/projectcalico/libcalico-go/lib/clientv3"
 	cerrors "github.com/projectcalico/libcalico-go/lib/errors"
-	cnet "github.com/projectcalico/libcalico-go/lib/net"
 	"github.com/projectcalico/libcalico-go/lib/options"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -253,78 +250,9 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 	ipAddrsNoIpam := annot["cni.projectcalico.org/ipAddrsNoIpam"]
 	ipAddrs := annot["cni.projectcalico.org/ipAddrs"]
 
-	// Switch based on which annotations are passed or not passed.
-	switch {
-	case ipAddrs == "" && ipAddrsNoIpam == "":
-		// Call the IPAM plugin.
-		result, err = utils.AddIPAM(conf, args, logger)
-		if err != nil {
-			return nil, err
-		}
-
-	case ipAddrs != "" && ipAddrsNoIpam != "":
-		// Can't have both ipAddrs and ipAddrsNoIpam annotations at the same time.
-		e := fmt.Errorf("can't have both annotations: 'ipAddrs' and 'ipAddrsNoIpam' in use at the same time")
-		logger.Error(e)
-		return nil, e
-
-	case ipAddrsNoIpam != "":
-		// Validate that we're allowed to use this feature.
-		if conf.IPAM.Type != "calico-ipam" {
-			e := fmt.Errorf("ipAddrsNoIpam is not compatible with configured IPAM: %s", conf.IPAM.Type)
-			logger.Error(e)
-			return nil, e
-		}
-		if !conf.FeatureControl.IPAddrsNoIpam {
-			e := fmt.Errorf("requested feature is not enabled: ip_addrs_no_ipam")
-			logger.Error(e)
-			return nil, e
-		}
-
-		// ipAddrsNoIpam annotation is set so bypass IPAM, and set the IPs manually.
-		overriddenResult, err := overrideIPAMResult(ipAddrsNoIpam, logger)
-		if err != nil {
-			return nil, err
-		}
-		logger.Debugf("Bypassing IPAM to set the result to: %+v", overriddenResult)
-
-		// Convert overridden IPAM result into current Result.
-		// This method fill in all the empty fields necessory for CNI output according to spec.
-		result, err = current.NewResultFromResult(overriddenResult)
-		if err != nil {
-			return nil, err
-		}
-
-		if len(result.IPs) == 0 {
-			return nil, errors.New("failed to build result")
-		}
-
-	case ipAddrs != "":
-		// Validate that we're allowed to use this feature.
-		if conf.IPAM.Type != "calico-ipam" {
-			e := fmt.Errorf("ipAddrs is not compatible with configured IPAM: %s", conf.IPAM.Type)
-			logger.Error(e)
-			return nil, e
-		}
-
-		// If the endpoint already exists, we need to attempt to release the previous IP addresses here
-		// since the ADD call will fail when it tries to reallocate the same IPs. releaseIPAddrs assumes
-		// that Calico IPAM is in use, which is OK here since only Calico IPAM supports the ipAddrs
-		// annotation.
-		if endpoint != nil {
-			logger.Info("Endpoint already exists and ipAddrs is set. Release any old IPs")
-			if err := releaseIPAddrs(endpoint.Spec.IPNetworks, calicoClient, logger); err != nil {
-				return nil, fmt.Errorf("failed to release ipAddrs: %s", err)
-			}
-		}
-
-		// When ipAddrs annotation is set, we call out to the configured IPAM plugin
-		// requesting the specific IP addresses included in the annotation.
-		result, err = ipAddrsResult(ipAddrs, conf, args, logger)
-		if err != nil {
-			return nil, err
-		}
-		logger.Debugf("IPAM result set to: %+v", result)
+	result, err = cni_default.ProcessIpAddrs(ipAddrs, ipAddrsNoIpam, conf, args, logger, calicoClient, endpoint)
+	if err != nil {
+		return nil, err
 	}
 
 	// Configure the endpoint (creating if required).
@@ -396,7 +324,7 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 			releaseIPAM()
 			return nil, fmt.Errorf("requested feature is not enabled: floating_ips")
 		}
-		ips, err := parseIPAddrs(floatingIPs, logger)
+		ips, err := cni_default.ParseIPAddrs(floatingIPs, logger)
 		if err != nil {
 			releaseIPAM()
 			return nil, err
@@ -494,240 +422,6 @@ func CmdDelK8s(ctx context.Context, c calicoclient.Interface, epIDs utils.WEPIde
 	return nil
 }
 
-// releaseIPAddrs calls directly into Calico IPAM to release the specified IP addresses.
-// NOTE: This function assumes Calico IPAM is in use, and calls into it directly rather than calling the IPAM plugin.
-func releaseIPAddrs(ipAddrs []string, calico calicoclient.Interface, logger *logrus.Entry) error {
-	// For each IP, call out to Calico IPAM to release it.
-	for _, ip := range ipAddrs {
-		log := logger.WithField("IP", ip)
-		log.Info("Releasing explicitly requested address")
-		cip, _, err := cnet.ParseCIDR(ip)
-		if err != nil {
-			return err
-		}
-		unallocated, err := calico.IPAM().ReleaseIPs(context.Background(), []cnet.IP{*cip})
-		if err != nil {
-			log.WithError(err).Error("Failed to release explicit IP")
-			return err
-		}
-		if len(unallocated) > 0 {
-			log.Warn("Asked to release address but it doesn't exist.")
-		} else {
-			log.Infof("Released explicit address: %s", ip)
-		}
-	}
-	return nil
-}
-
-// ipAddrsResult parses the ipAddrs annotation and calls the configured IPAM plugin for
-// each IP passed to it by setting the IP field in CNI_ARGS, and returns the result of calling the IPAM plugin.
-// Example annotation value string: "[\"10.0.0.1\", \"2001:db8::1\"]"
-func ipAddrsResult(ipAddrs string, conf types.NetConf, args *skel.CmdArgs, logger *logrus.Entry) (*current.Result, error) {
-	logger.Infof("Parsing annotation \"cni.projectcalico.org/ipAddrs\":%s", ipAddrs)
-
-	// We need to make sure there is only one IPv4 and/or one IPv6
-	// passed in, since CNI spec only supports one of each right now.
-	ipList, err := validateAndExtractIPs(ipAddrs, "cni.projectcalico.org/ipAddrs", logger)
-	if err != nil {
-		return nil, err
-	}
-
-	result := current.Result{}
-
-	// Go through all the IPs passed in as annotation value and call IPAM plugin
-	// for each, and populate the result variable with IP4 and/or IP6 IPs returned
-	// from the IPAM plugin.
-	for _, ip := range ipList {
-		// Call callIPAMWithIP with the ip address.
-		r, err := callIPAMWithIP(ip, conf, args, logger)
-		if err != nil {
-			return nil, fmt.Errorf("error getting IP from IPAM: %s", err)
-		}
-
-		result.IPs = append(result.IPs, r.IPs[0])
-		logger.Debugf("Adding IPv%s: %s to result", r.IPs[0].Version, ip.String())
-	}
-
-	return &result, nil
-}
-
-// callIPAMWithIP sets CNI_ARGS with the IP and calls the IPAM plugin with it
-// to get current.Result and then it unsets the IP field from CNI_ARGS ENV var,
-// so it doesn't pollute the subsequent requests.
-func callIPAMWithIP(ip net.IP, conf types.NetConf, args *skel.CmdArgs, logger *logrus.Entry) (*current.Result, error) {
-
-	// Save the original value of the CNI_ARGS ENV var for backup.
-	originalArgs := os.Getenv("CNI_ARGS")
-	logger.Debugf("Original CNI_ARGS=%s", originalArgs)
-
-	ipamArgs := struct {
-		cnitypes.CommonArgs
-		IP net.IP `json:"ip,omitempty"`
-	}{}
-
-	if err := cnitypes.LoadArgs(args.Args, &ipamArgs); err != nil {
-		return nil, err
-	}
-
-	if ipamArgs.IP != nil {
-		logger.Errorf("'IP' variable already set in CNI_ARGS environment variable.")
-	}
-
-	// Request the provided IP address using the IP CNI_ARG.
-	// See: https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md#cni_args for more info.
-	newArgs := originalArgs + ";IP=" + ip.String()
-	logger.Debugf("New CNI_ARGS=%s", newArgs)
-
-	// Set CNI_ARGS to the new value.
-	err := os.Setenv("CNI_ARGS", newArgs)
-	if err != nil {
-		return nil, fmt.Errorf("error setting CNI_ARGS environment variable: %v", err)
-	}
-
-	// Run the IPAM plugin.
-	logger.Debugf("Calling IPAM plugin %s", conf.IPAM.Type)
-	r, err := ipam.ExecAdd(conf.IPAM.Type, args.StdinData)
-	if err != nil {
-		// Restore the CNI_ARGS ENV var to it's original value,
-		// so the subsequent calls don't get polluted by the old IP value.
-		if err := os.Setenv("CNI_ARGS", originalArgs); err != nil {
-			logger.Errorf("Error setting CNI_ARGS environment variable: %v", err)
-		}
-		return nil, err
-	}
-	logger.Debugf("IPAM plugin returned: %+v", r)
-
-	// Restore the CNI_ARGS ENV var to it's original value,
-	// so the subsequent calls don't get polluted by the old IP value.
-	if err := os.Setenv("CNI_ARGS", originalArgs); err != nil {
-		// Need to clean up IP allocation if this step doesn't succeed.
-		utils.ReleaseIPAllocation(logger, conf, args)
-		logger.Errorf("Error setting CNI_ARGS environment variable: %v", err)
-		return nil, err
-	}
-
-	// Convert IPAM result into current Result.
-	// IPAM result has a bunch of fields that are optional for an IPAM plugin
-	// but required for a CNI plugin, so this is to populate those fields.
-	// See CNI Spec doc for more details.
-	ipamResult, err := current.NewResultFromResult(r)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(ipamResult.IPs) == 0 {
-		return nil, errors.New("IPAM plugin returned missing IP config")
-	}
-
-	return ipamResult, nil
-}
-
-// overrideIPAMResult generates current.Result like the one produced by IPAM plugin,
-// but sets IP field manually since IPAM is bypassed with this annotation.
-// Example annotation value string: "[\"10.0.0.1\", \"2001:db8::1\"]"
-func overrideIPAMResult(ipAddrsNoIpam string, logger *logrus.Entry) (*current.Result, error) {
-	logger.Infof("Parsing annotation \"cni.projectcalico.org/ipAddrsNoIpam\":%s", ipAddrsNoIpam)
-
-	// We need to make sure there is only one IPv4 and/or one IPv6
-	// passed in, since CNI spec only supports one of each right now.
-	ipList, err := validateAndExtractIPs(ipAddrsNoIpam, "cni.projectcalico.org/ipAddrsNoIpam", logger)
-	if err != nil {
-		return nil, err
-	}
-
-	result := current.Result{}
-
-	// Go through all the IPs passed in as annotation value and populate
-	// the result variable with IP4 and/or IP6 IPs.
-	for _, ip := range ipList {
-		var version string
-		var mask net.IPMask
-
-		if ip.To4() != nil {
-			version = "4"
-			mask = net.CIDRMask(32, 32)
-
-		} else {
-			version = "6"
-			mask = net.CIDRMask(128, 128)
-		}
-
-		ipConf := &current.IPConfig{
-			Version: version,
-			Address: net.IPNet{
-				IP:   ip,
-				Mask: mask,
-			},
-		}
-		result.IPs = append(result.IPs, ipConf)
-		logger.Debugf("Adding IPv%s: %s to result", ipConf.Version, ip.String())
-	}
-
-	return &result, nil
-}
-
-// validateAndExtractIPs is a utility function that validates the passed IP list to make sure
-// there is one IPv4 and/or one IPv6 and then returns the slice of IPs.
-func validateAndExtractIPs(ipAddrs string, annotation string, logger *logrus.Entry) ([]net.IP, error) {
-	// Parse IPs from JSON.
-	ips, err := parseIPAddrs(ipAddrs, logger)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse IPs %s for annotation \"%s\": %s", ipAddrs, annotation, err)
-	}
-
-	// annotation value can't be empty.
-	if len(ips) == 0 {
-		return nil, fmt.Errorf("annotation \"%s\" specified but empty", annotation)
-	}
-
-	var hasIPv4, hasIPv6 bool
-	var ipList []net.IP
-
-	// We need to make sure there is only one IPv4 and/or one IPv6
-	// passed in, since CNI spec only supports one of each right now.
-	for _, ip := range ips {
-		ipAddr := net.ParseIP(ip)
-		if ipAddr == nil {
-			logger.WithField("IP", ip).Error("Invalid IP format")
-			return nil, fmt.Errorf("invalid IP format: %s", ip)
-		}
-
-		if ipAddr.To4() != nil {
-			if hasIPv4 {
-				// Check if there is already has been an IPv4 in the list, as we only support one IPv4 and/or one IPv6 per interface for now.
-				return nil, fmt.Errorf("cannot have more than one IPv4 address for \"%s\" annotation", annotation)
-			}
-			hasIPv4 = true
-		} else {
-			if hasIPv6 {
-				// Check if there is already has been an IPv6 in the list, as we only support one IPv4 and/or one IPv6 per interface for now.
-				return nil, fmt.Errorf("cannot have more than one IPv6 address for \"%s\" annotation", annotation)
-			}
-			hasIPv6 = true
-		}
-
-		// Append the IP to ipList slice.
-		ipList = append(ipList, ipAddr)
-	}
-
-	return ipList, nil
-}
-
-// parseIPAddrs is a utility function that parses string of IPs in json format that are
-// passed in as a string and returns a slice of string with IPs.
-// It also makes sure the slice isn't empty.
-func parseIPAddrs(ipAddrsStr string, logger *logrus.Entry) ([]string, error) {
-	var ips []string
-
-	err := json.Unmarshal([]byte(ipAddrsStr), &ips)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse '%s' as JSON: %s", ipAddrsStr, err)
-	}
-
-	logger.Debugf("IPs parsed: %v", ips)
-
-	return ips, nil
-}
 
 func newK8sClient(conf types.NetConf, logger *logrus.Entry) (*kubernetes.Clientset, error) {
 	// Some config can be passed in a kubeconfig file


### PR DESCRIPTION
This adds fixed IPs support to Mesos similar to k8s annotations via NetworkInfo.Labels and also structures code to cni_default and k8s modules.

Example of usage (fragment of Marathon's app decription):
```
"networks": [
    {
      "name": "cni-net-fixedpool",
      "mode": "container",
      "labels": {
        "cni.projectcalico.org/ipAddrs": "[\"10.11.12.13\"]"
      }
    }
  ],
  "upgradeStrategy": {
    "maximumOverCapacity": 0,
    "minimumHealthCapacity": 0
  }
```