### PR TITLE
Upgrade base image up to debian:buster-slim

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM debian:9.8-slim
+FROM debian:buster-slim
 
 LABEL maintainer "Casey Davenport <casey@tigera.io>"
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM arm64v8/debian:9.8-slim
+FROM arm64v8/debian:buster-slim
 
 LABEL maintainer "Casey Davenport <casey@tigera.io>"
 

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,4 +1,4 @@
-FROM ppc64le/debian:9.8-slim
+FROM ppc64le/debian:buster-slim
 
 LABEL maintainer "Casey Davenport <casey@tigera.io>"
 

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -1,4 +1,4 @@
-FROM s390x/debian:9.8-slim
+FROM s390x/debian:buster-slim
 
 LABEL maintainer "LoZ Open Source Ecosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)"
 


### PR DESCRIPTION
## Description
Bumping base image up to `debian:buster-slim` to be consistent with calico/node.

## Todos
- [ ] ~~Tests~~
- [ ] ~~Documentation~~
- [ ] ~~Release note~~

## Release Note
```release-note
None required
```
