### PR TITLE
Switching image base to debian:9.8-slim

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:9.8-slim
 
 LABEL maintainer "Casey Davenport <casey@tigera.io>"
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM arm64v8/debian:buster-slim
+FROM arm64v8/debian:9.8-slim
 
 LABEL maintainer "Casey Davenport <casey@tigera.io>"
 

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,4 +1,4 @@
-FROM ppc64le/debian:buster-slim
+FROM ppc64le/debian:9.8-slim
 
 LABEL maintainer "Casey Davenport <casey@tigera.io>"
 

--- a/Dockerfile.s390x
+++ b/Dockerfile.s390x
@@ -1,4 +1,4 @@
-FROM s390x/debian:buster-slim
+FROM s390x/debian:9.8-slim
 
 LABEL maintainer "LoZ Open Source Ecosystem (https://www.ibm.com/developerworks/community/groups/community/lozopensource)"
 


### PR DESCRIPTION
## Description
Switching image base to debian:9.8-slim (aka stretch-slim).

The reason for the switch is that Debian stretch is the current stable LTS release.

This is a patch for `release-v3.7` based on the following PR:
https://github.com/projectcalico/cni-plugin/pull/739

## Todos
- [ ] Tests
- [ ] ~~Documentation~~
- [ ] ~~Release note~~

## Release Note
```release-note
CNI base image switched to Debian stretch (LTS)
```
