### PR TITLE
Increase K8s version to 1.14.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ endif
 # fail if unable to download
 CURL=curl -C - -sSf
 
-K8S_VERSION?=v1.11.3
+K8S_VERSION?=v1.14.1
 CNI_VERSION=v0.7.5
 
 # Get version from git.


### PR DESCRIPTION
Increase K8s used for tests to [1.14.1] (https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.14.md )