### PR TITLE
Add bandwidth plugin and update cni plugins to v0.8.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ endif
 CURL=curl -C - -sSf
 
 K8S_VERSION?=v1.14.1
-CNI_VERSION=v0.7.5
+CNI_VERSION=v0.8.0
 
 # Get version from git.
 GIT_VERSION:=$(shell git describe --tags --dirty --always)
@@ -271,11 +271,11 @@ endif
 	touch $@
 
 .PHONY: fetch-cni-bins
-fetch-cni-bins: $(BIN)/flannel $(BIN)/loopback $(BIN)/host-local $(BIN)/portmap $(BIN)/tuning
+fetch-cni-bins: $(BIN)/flannel $(BIN)/loopback $(BIN)/host-local $(BIN)/portmap $(BIN)/tuning $(BIN)/bandwidth
 
-$(BIN)/flannel $(BIN)/loopback $(BIN)/host-local $(BIN)/portmap $(BIN)/tuning:
+$(BIN)/flannel $(BIN)/loopback $(BIN)/host-local $(BIN)/portmap $(BIN)/tuning $(BIN)/bandwidth:
 	mkdir -p $(BIN)
-	$(CURL) -L --retry 5 https://github.com/containernetworking/plugins/releases/download/$(CNI_VERSION)/cni-plugins-$(ARCH)-$(CNI_VERSION).tgz | tar -xz -C $(BIN) ./flannel ./loopback ./host-local ./portmap ./tuning
+	$(CURL) -L --retry 5 https://github.com/containernetworking/plugins/releases/download/$(CNI_VERSION)/cni-plugins-linux-$(ARCH)-$(CNI_VERSION).tgz | tar -xz -C $(BIN) ./flannel ./loopback ./host-local ./portmap ./tuning ./bandwidth
 
 ###############################################################################
 # Static checks


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

- New feature: adding the bandwidth cni plugin: (https://github.com/containernetworking/plugins/tree/master/plugins/meta/bandwidth) which allows it to use tc with Kubernetes e.g. https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/#support-traffic-shaping without the need to manually install the bandwidth plugin.
- Update the cni plugins to `v0.8.0` since the bandwidth plugin is new

Fixes: https://github.com/projectcalico/calico/issues/797

## Todos
- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Update cni-plugins version to v0.8.0 and add bandwidth plugin for traffic shaping.
```
