### PR TITLE
Fix upgrade-ipam lockin wrong directory

### DIFF
--- a/pkg/upgrade/migrate.go
+++ b/pkg/upgrade/migrate.go
@@ -199,7 +199,7 @@ func Migrate(ctxt context.Context, c client.Interface, nodename string) error {
 	// against racing with any remaining host-local processes which might be allocating
 	// IP addresses.
 	log.Info("acquiring lock on host-local IPAM")
-	hostLocal, err := disk.New(ipAllocPath, "")
+	hostLocal, err := disk.New("", ipAllocPath)
 	if err != nil {
 		return fmt.Errorf("failed to initialize host-local IPAM: %s", err)
 	}


### PR DESCRIPTION
## Description

This is a bug fix for an issue observed when upgrading from Calico 3.5.4 to 3.7.2 (see #749).
I am currently manually testing this fix and am open to any suggestions.

### Explanation
The old call to `disk.New` causes creation of `/var/lib/cni/networks/var/lib/cni/networks/k8s-pod-network`. This is because supplying `""` as `dataDir` causes the default of `/var/lib/cni/networks` to be used. The `network` value of `"/var/lib/cni/networks/k8s-pod-network/"` is then concatenated to that default value.
This in turn causes the wrong directory to be locked.


<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
