### PR TITLE
Override for kube service host and port

### DIFF
--- a/k8s-install/scripts/install-cni.sh
+++ b/k8s-install/scripts/install-cni.sh
@@ -147,7 +147,7 @@ kind: Config
 clusters:
 - name: local
   cluster:
-    server: ${KUBERNETES_SERVICE_PROTOCOL:-https}://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}
+    server: ${KUBERNETES_SERVICE_PROTOCOL:-https}://[${KUBECONFIG_HOST:-$KUBERNETES_SERVICE_HOST}]:${KUBECONFIG_PORT:-$KUBERNETES_SERVICE_PORT}
     $TLS_CFG
 users:
 - name: calico


### PR DESCRIPTION
This will allow users to add an env var to the container that
will be used as the Kubernetes service host/port in the generated
Kubeconfig. This will be useful in Kubespray installs that use a local
Nginx proxy for all API service requests running on 127.0.0.1:6443.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
