### PR TITLE
Add etcd SRV discovery support

### DIFF
--- a/internal/pkg/utils/utils.go
+++ b/internal/pkg/utils/utils.go
@@ -482,6 +482,11 @@ func CreateClient(conf types.NetConf) (client.Interface, error) {
 			return nil, err
 		}
 	}
+	if conf.EtcdDiscoverySrv != "" {
+		if err := os.Setenv("ETCD_DISCOVERY_SRV", conf.EtcdDiscoverySrv); err != nil {
+			return nil, err
+		}
+	}
 	if conf.EtcdScheme != "" {
 		if err := os.Setenv("ETCD_SCHEME", conf.EtcdScheme); err != nil {
 			return nil, err

--- a/k8s-install/scripts/calico.conf.default
+++ b/k8s-install/scripts/calico.conf.default
@@ -2,6 +2,7 @@
     "name": "k8s-pod-network",
     "type": "calico",
     "etcd_endpoints": "__ETCD_ENDPOINTS__",
+    "etcd_discovery_srv": "__ETCD_DISCOVERY_SRV__",
     "etcd_key_file": "__ETCD_KEY_FILE__",
     "etcd_cert_file": "__ETCD_CERT_FILE__",
     "etcd_ca_cert_file": "__ETCD_CA_CERT_FILE__",

--- a/k8s-install/scripts/expected_10-calico.conf
+++ b/k8s-install/scripts/expected_10-calico.conf
@@ -2,6 +2,7 @@
     "name": "k8s-pod-network",
     "type": "calico",
     "etcd_endpoints": "",
+    "etcd_discovery_srv": "",
     "etcd_key_file": "",
     "etcd_cert_file": "",
     "etcd_ca_cert_file": "",

--- a/k8s-install/scripts/expected_10-calico.conf.alternate
+++ b/k8s-install/scripts/expected_10-calico.conf.alternate
@@ -2,6 +2,7 @@
     "name": "alternate",
     "type": "calico",
     "etcd_endpoints": "",
+    "etcd_discovery_srv": "",
     "etcd_key_file": "",
     "etcd_cert_file": "",
     "etcd_ca_cert_file": "",

--- a/k8s-install/scripts/install-cni.sh
+++ b/k8s-install/scripts/install-cni.sh
@@ -176,6 +176,7 @@ sed -i s~__ETCD_CERT_FILE__~"${CNI_CONF_ETCD_CERT:-}"~g $TMP_CONF
 sed -i s~__ETCD_KEY_FILE__~"${CNI_CONF_ETCD_KEY:-}"~g $TMP_CONF
 sed -i s~__ETCD_CA_CERT_FILE__~"${CNI_CONF_ETCD_CA:-}"~g $TMP_CONF
 sed -i s~__ETCD_ENDPOINTS__~"${ETCD_ENDPOINTS:-}"~g $TMP_CONF
+sed -i s~__ETCD_DISCOVERY_SRV__~"${ETCD_DISCOVERY_SRV:-}"~g $TMP_CONF
 sed -i s~__LOG_LEVEL__~"${LOG_LEVEL:-warn}"~g $TMP_CONF
 
 CNI_CONF_NAME=${CNI_CONF_NAME:-10-calico.conf}

--- a/k8s-install/scripts/test-templates/calico.conf.alternate
+++ b/k8s-install/scripts/test-templates/calico.conf.alternate
@@ -2,6 +2,7 @@
     "name": "alternate",
     "type": "calico",
     "etcd_endpoints": "__ETCD_ENDPOINTS__",
+    "etcd_discovery_srv": "__ETCD_DISCOVERY_SRV__",
     "etcd_key_file": "__ETCD_KEY_FILE__",
     "etcd_cert_file": "__ETCD_CERT_FILE__",
     "etcd_ca_cert_file": "__ETCD_CA_CERT_FILE__",

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -81,6 +81,7 @@ type NetConf struct {
 	NodenameFileOptional bool              `json:"nodename_file_optional"`
 	DatastoreType        string            `json:"datastore_type"`
 	EtcdEndpoints        string            `json:"etcd_endpoints"`
+	EtcdDiscoverySrv     string            `json:"etcd_discovery_srv"`
 	LogLevel             string            `json:"log_level"`
 	Policy               Policy            `json:"policy"`
 	Kubernetes           Kubernetes        `json:"kubernetes"`


### PR DESCRIPTION
## Description

Support the `etcdDiscoverySrv`/`$ETCD_DISCOVERY_SRV` option added to the configuration in https://github.com/projectcalico/libcalico-go/pull/1086/

## Todos
- [ ] Tests
- [x] Documentation
- [X] Release note

## Release Note

```release-note
Adds support for the etcdDiscoverySrv option / ETCD_DISCOVERY_SRV environment variable when using the etcdv3 datastore.
```
