### PR TITLE
Handle migrating an IP that is already migrated

### DIFF
--- a/pkg/upgrade/migrate.go
+++ b/pkg/upgrade/migrate.go
@@ -1,4 +1,4 @@
-// Copyright 2015 Tigera Inc
+// Copyright 2015-2019 Tigera Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,6 +27,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/projectcalico/cni-plugin/internal/pkg/utils"
 	v3 "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	bapi "github.com/projectcalico/libcalico-go/lib/backend/api"
@@ -37,7 +39,6 @@ import (
 	"github.com/projectcalico/libcalico-go/lib/net"
 	cnet "github.com/projectcalico/libcalico-go/lib/net"
 	"github.com/projectcalico/libcalico-go/lib/options"
-	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -299,7 +300,7 @@ func Migrate(ctxt context.Context, c client.Interface, nodename string) error {
 				ipam.AttributeNamespace: pod.Namespace,
 			},
 		}); err != nil {
-			if _, ok := err.(errors.ErrorResourceAlreadyExists); !ok {
+			if _, ok := err.(errors.ErrorResourceAlreadyExists); !(ok || strings.Contains(err.Error(), "already assigned")) {
 				return fmt.Errorf("failed to assign IP to calico backend: %s", err)
 			}
 			// Pod IP already assigned - likely failed to remove the file on the last attempt.


### PR DESCRIPTION
This is a partial fix for https://github.com/projectcalico/cni-plugin/issues/749, q.v.

Clearly the intent of the code here is to be resilient in the case
where an IP (as indicated by a host-local file) has already been
assigned in the Calico data model; but the condition used to detect this
case was insufficient.  Here's a log excerpt that shows what the actual
error is here:
```
2019-05-27 15:31:52.774 [INFO][1] migrate.go 238: reading files from host-local IPAM data dir...
2019-05-27 15:31:52.774 [INFO][1] migrate.go 247: processing file... file="100.64.3.11"
2019-05-27 15:31:52.774 [INFO][1] migrate.go 291: assinging pod IP to Calico IPAM... file="100.64.3.11"
2019-05-27 15:31:52.774 [INFO][1] ipam.go 581: Assigning IP 100.64.3.11 to host: kworker-be-sandbox-iz2-bap004
2019-05-27 15:31:52.791 [ERROR][1] ipam.go 635: Failed to assign address 100.64.3.11: Address already assigned in block
```

