### PR TITLE
Automated cherry pick of #750: Fix upgrade-ipam lockin wrong directory

### DIFF
--- a/pkg/upgrade/migrate.go
+++ b/pkg/upgrade/migrate.go
@@ -199,7 +199,7 @@ func Migrate(ctxt context.Context, c client.Interface, nodename string) error {
 	// against racing with any remaining host-local processes which might be allocating
 	// IP addresses.
 	log.Info("acquiring lock on host-local IPAM")
-	hostLocal, err := disk.New(ipAllocPath, "")
+	hostLocal, err := disk.New("", ipAllocPath)
 	if err != nil {
 		return fmt.Errorf("failed to initialize host-local IPAM: %s", err)
 	}


### PR DESCRIPTION
Cherry pick of #750 on release-v3.7.

#750: Fix upgrade-ipam lockin wrong directory

```release-note
Fix locking of host-local IPAM directory on upgrade (@maxbischoff)
```