### PR TITLE
enforce reproducible builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -224,8 +224,8 @@ $(BIN)/calico $(BIN)/calico-ipam: local_build $(SRC_FILES)
 	$(DOCKER_RUN) \
 	-v $(CURDIR)/$(BIN):/go/src/$(PACKAGE_NAME)/$(BIN):rw \
 	    $(CALICO_BUILD) sh -c '\
-		go build -v -o $(BIN)/calico -ldflags "-X main.VERSION=$(GIT_VERSION) -s -w" ./cmd/calico && \
-		go build -v -o $(BIN)/calico-ipam -ldflags "-X main.VERSION=$(GIT_VERSION) -s -w" ./cmd/calico-ipam'
+		go build -v -o $(BIN)/calico -ldflags "-X main.VERSION=$(GIT_VERSION) -s -w" $(BUILD_FLAGS) ./cmd/calico && \
+		go build -v -o $(BIN)/calico-ipam -ldflags "-X main.VERSION=$(GIT_VERSION) -s -w" $(BUILD_FLAGS) ./cmd/calico-ipam'
 
 ###############################################################################
 # Building the image
@@ -448,6 +448,10 @@ test-install-cni: image k8s-install/scripts/install_cni.test
 .PHONY: ci
 ## Run what CI runs
 ci: clean static-checks test-cni-versions image-all test-install-cni
+
+# Run -mod=readonly in CI for reproducible builds. If this fails, it's likely the PR has not included 
+ci: BUILD_FLAGS = -mod=readonly
+cd: BUILD_FLAGS = -mod=readonly
 
 ## Deploys images to registry
 cd:


### PR DESCRIPTION
pass '-mod=readonly' to 'go build' in CI/CD to ensure that go doesn't update go.mod file (which will cause a --dirty build)

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
