### PR TITLE
Automated cherry pick of #790: Add assertion that CI builds do not result in dirty state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -447,7 +447,7 @@ test-install-cni: image k8s-install/scripts/install_cni.test
 ###############################################################################
 .PHONY: ci
 ## Run what CI runs
-ci: clean static-checks test-cni-versions image-all test-install-cni
+ci: clean build assert-not-dirty static-checks test-cni-versions image-all test-install-cni
 
 ## Deploys images to registry
 cd:
@@ -459,6 +459,12 @@ ifndef BRANCH_NAME
 endif
 	$(MAKE) tag-images-all push-all push-manifests push-non-manifests  IMAGETAG=${BRANCH_NAME} EXCLUDEARCH="$(EXCLUDEARCH)"
 	$(MAKE) tag-images-all push-all push-manifests push-non-manifests  IMAGETAG=$(shell git describe --tags --dirty --always --long) EXCLUDEARCH="$(EXCLUDEARCH)"
+
+
+# Assert no local changes after a clean build. This helps catch errors resulting from
+# misconfigured go.mod / go.sum / gitignore, etc.
+assert-not-dirty: 
+	@./hack/check-dirty.sh
 
 ###############################################################################
 # Release

--- a/hack/check-dirty.sh
+++ b/hack/check-dirty.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [[ $(git status --porcelain) != '' ]]; then
+	echo "$(git status)"
+	echo ""
+	echo "ERROR: Local working tree is not clean. Make sure clean builds do not produce a dirty tree."
+	echo ""
+	exit 1
+fi


### PR DESCRIPTION
Cherry pick of #790 on release-v3.9.

#790: Add assertion that CI builds do not result in dirty state