### PR TITLE
Change base image from debian slim => ubi

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 !k8s-install/scripts/install-cni.sh
 !k8s-install/scripts/calico.conf.default
 !bin/
+!LICENSE

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,10 +1,35 @@
-FROM debian:10-slim
+# Copyright (c) 2015-2019 Tigera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-LABEL maintainer "Casey Davenport <casey@tigera.io>"
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+ARG GIT_VERSION=unknown
+
+LABEL name="Calico Networking for CNI" \
+      vendor="Project Calico" \
+      version=$GIT_VERSION \
+      release="1" \
+      summary="Calico Networking for CNI" \
+      description="Calico Networking for CNI includes a CNI networking plugin and CNI IPAM plugin" \
+      maintainer="laurence@tigera.io"
 
 ADD bin/amd64/ /opt/cni/bin/
 ADD k8s-install/scripts/install-cni.sh /install-cni.sh
 ADD k8s-install/scripts/calico.conf.default /calico.conf.tmp
+
+RUN mkdir /licenses
+COPY LICENSE /licenses
 
 ENV PATH=$PATH:/opt/cni/bin
 WORKDIR /opt/cni/bin

--- a/Makefile
+++ b/Makefile
@@ -291,7 +291,7 @@ sub-tag-images-%:
 	$(MAKE) tag-images ARCH=$* IMAGETAG=$(IMAGETAG)
 
 $(DEPLOY_CONTAINER_MARKER): Dockerfile.$(ARCH) build fetch-cni-bins
-	GO111MODULE=on docker build -t $(BUILD_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) -f Dockerfile.$(ARCH) .
+	GO111MODULE=on docker build -t $(BUILD_IMAGE):latest-$(ARCH) --build-arg QEMU_IMAGE=$(CALICO_BUILD) --build-arg GIT_VERSION=$(GIT_VERSION) -f Dockerfile.$(ARCH) .
 ifeq ($(ARCH),amd64)
 	# Need amd64 builds tagged as :latest because Semaphore depends on that
 	docker tag $(BUILD_IMAGE):latest-$(ARCH) $(BUILD_IMAGE):latest


### PR DESCRIPTION
## Description

Related PR: https://github.com/projectcalico/node/pull/362
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Calico component images are now using ubi for the base image
```
