### PR TITLE
Add timeouts to cmdAdd() and cmdDel()

### DIFF
--- a/pkg/ipamplugin/ipam_plugin.go
+++ b/pkg/ipamplugin/ipam_plugin.go
@@ -155,6 +155,9 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 
 	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	defer cancel()
+
 	r := &current.Result{}
 	if ipamArgs.IP != nil {
 		logger.Infof("Calico CNI IPAM request IP: %v", ipamArgs.IP)
@@ -298,6 +301,9 @@ func cmdDel(args *skel.CmdArgs) error {
 
 	logger.Info("Releasing address using handleID")
 	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	defer cancel()
+
 	if err := calicoClient.IPAM().ReleaseByHandle(ctx, handleID); err != nil {
 		if _, ok := err.(errors.ErrorResourceDoesNotExist); !ok {
 			logger.WithError(err).Error("Failed to release address")

--- a/pkg/ipamplugin/ipam_plugin.go
+++ b/pkg/ipamplugin/ipam_plugin.go
@@ -155,7 +155,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	r := &current.Result{}
@@ -301,7 +301,7 @@ func cmdDel(args *skel.CmdArgs) error {
 
 	logger.Info("Releasing address using handleID")
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	if err := calicoClient.IPAM().ReleaseByHandle(ctx, handleID); err != nil {


### PR DESCRIPTION
Proposed fix for https://github.com/projectcalico/calico/issues/2902