### PR TITLE
Connect to datastore before installing CNI config

### DIFF
--- a/k8s-install/scripts/install-cni.sh
+++ b/k8s-install/scripts/install-cni.sh
@@ -191,6 +191,7 @@ sed -i s/__SERVICEACCOUNT_TOKEN__/"${SERVICEACCOUNT_TOKEN:-}"/g $TMP_CONF
 # Before actually putting the config file in place, block on successful connection
 # to the datastore. Once config is in place, Kubelet will start scheduling pods
 # and these will fail if we can't reach the data store for some reason.
+SKIP_DATASTORE_CONNECTION_CHECK=${SKIP_DATASTORE_CONNECTION_CHECK:-""}
 if [-z "${SKIP_DATASTORE_CONNECTION_CHECK}"]; then
   until /opt/cni/bin/calico -t < $TMP_CONF
   do

--- a/k8s-install/scripts/install-cni.sh
+++ b/k8s-install/scripts/install-cni.sh
@@ -188,6 +188,16 @@ echo "CNI config: $(cat ${TMP_CONF})"
 
 sed -i s/__SERVICEACCOUNT_TOKEN__/"${SERVICEACCOUNT_TOKEN:-}"/g $TMP_CONF
 
+# Before actually putting the config file in place, block on successful connection
+# to the datastore. Once config is in place, Kubelet will start scheduling pods
+# and these will fail if we can't reach the data store for some reason.
+if [-z "${SKIP_DATASTORE_CONNECTION_CHECK}"]; then
+  until /opt/cni/bin/calico -t < $TMP_CONF
+  do
+    echo "Failed to reach datastore"; sleep 1;
+  done
+fi
+
 # Delete old CNI config files for upgrades.
 if [ "${CNI_CONF_NAME}" != "${CNI_OLD_CONF_NAME}" ]; then
     rm -f "/host/etc/cni/net.d/${CNI_OLD_CONF_NAME}"

--- a/k8s-install/scripts/install_cni_test.go
+++ b/k8s-install/scripts/install_cni_test.go
@@ -169,6 +169,7 @@ var _ = Describe("install-cni.sh tests", func() {
 		It("should use CNI_NETWORK_CONFIG", func() {
 			err := runCniContainer(
 				"-e", "CNI_NETWORK_CONFIG=filecontents",
+				"-e", "SKIP_DATASTORE_CONNECTION_CHECK=true",
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -181,6 +182,7 @@ var _ = Describe("install-cni.sh tests", func() {
 			err := runCniContainer(
 				"-e", "CNI_NETWORK_CONFIG='oops, I used the CNI_NETWORK_CONFIG'",
 				"-e", "CNI_NETWORK_CONFIG_FILE=/template/calico.conf.alternate",
+				"-e", "SKIP_DATASTORE_CONNECTION_CHECK=true",
 			)
 			Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Signed-off-by: Spike Curtis <spike@tigera.io>

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
If we can't connect to the datastore, but install the CNI config, Kubelet may start scheduling pods, which will just fail on this node.  So, before adding the CNI config, test a connection to the datastore. Once that is successful, proceed to add the CNI config.  If the datastore connection fails we retry in a loop.


## Todos
- [ ] Tests
- [x] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
wait for successful connect to datastore before configuring kubelet with CNI plugin
```
