### PR TITLE
Fix containerID read during IPAM migration

### DIFF
--- a/pkg/upgrade/migrate.go
+++ b/pkg/upgrade/migrate.go
@@ -288,7 +288,8 @@ func Migrate(ctxt context.Context, c client.Interface, nodename string) error {
 		if err != nil {
 			return fmt.Errorf("failed to read file %s: %s", fname, err)
 		}
-		containerID := string(b)
+		// The containerID is the first line in the file.
+		containerID := strings.TrimSpace(strings.Split(string(b), "\n")[0])
 
 		// Get the pod resource associated with the IP.
 		pod, ok := podIPMap[f.Name()]


### PR DESCRIPTION

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Bug fix. 

Fixes https://github.com/projectcalico/cni-plugin/issues/821

The host-local IPAM plugin [writes the interface name](https://github.com/containernetworking/plugins/blob/ec8f6c99d030bd75337ae8bfc62fc02cdc462528/plugins/ipam/host-local/backend/disk/backend.go#L69) in the file where the container IP is stored. The calico-ipam plugin needs to parse the file during a migration or else it'll try and always fail to create a handle.

## Todos
- [ ] Tests

Couldn't find any tests for this code path, if any of the reviewers can point me to an example I'd be happy to contribute one as well.

- ~[ ] Documentation~
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix a bug when checking the containerID during an IPAM upgrade from host-local to calico-ipam
```
