### PR TITLE
Fix release image push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PACKAGE_NAME=github.com/projectcalico/cni-plugin
-GO_BUILD_VER=v0.31
+GO_BUILD_VER=v0.34
 
 # This needs to be evaluated before the common makefile is included.
 # This var contains some default values that the common makefile may append to.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 PACKAGE_NAME=github.com/projectcalico/cni-plugin
 GO_BUILD_VER=v0.31
 
+# This needs to be evaluated before the common makefile is included.
+# This var contains some default values that the common makefile may append to.
+PUSH_IMAGES?=$(BUILD_IMAGE) quay.io/calico/cni
+
 ###############################################################################
 # Download and include Makefile.common
 #   Additions to EXTRA_DOCKER_ARGS need to happen before the include since
@@ -44,7 +48,6 @@ CNI_SPEC_VERSION?=0.3.1
 BUILD_IMAGE?=calico/cni
 DEPLOY_CONTAINER_MARKER=cni_deploy_container-$(ARCH).created
 
-PUSH_IMAGES?=$(BUILD_IMAGE) quay.io/calico/cni
 RELEASE_IMAGES?=gcr.io/projectcalico-org/cni eu.gcr.io/projectcalico-org/cni asia.gcr.io/projectcalico-org/cni us.gcr.io/projectcalico-org/cni
 
 ETCD_CONTAINER ?= quay.io/coreos/etcd:$(ETCD_VERSION)-$(BUILDARCH)


### PR DESCRIPTION
## Description

The invocation ` make tag-images-all RELEASE=true IMAGETAG=<tag>` was not tagging and pushing the image to gcr.io registries.

This PR addresses part of that: the `PUSH_IMAGES` variable needs to be defined before `Makefile.common` is included, otherwise `PUSH_IMAGES` will lose its initial default values. The second part is fixed in the common Makefile in https://github.com/projectcalico/go-build/pull/95

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
