### PR TITLE
Change ppc64le base image from debian slim to UBI

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,4 +1,4 @@
-FROM ppc64le/debian:9.8-slim
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 LABEL maintainer "Casey Davenport <casey@tigera.io>"
 


### PR DESCRIPTION
Mirroring a change made in https://github.com/projectcalico/cni-plugin/commit/3b06d4e2a2862e9427b58b36143fb89f1efda059

to the powerpc Dockerfile. This solves a number of security issues reported in the ppc64le flavor of the CNI image hosted on quay

https://quay.io/repository/calico/cni/manifest/sha256:3496e150ef6b6444ba128e9414fec4644869c393dc5cfe38b28462c70b45bce1?tab=vulnerabilities&fixable=true