### PR TITLE
Add `hostname` to the image and pin image

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1-407
 
 ARG GIT_VERSION=unknown
 
@@ -28,7 +28,7 @@ ADD bin/amd64/ /opt/cni/bin/
 ADD k8s-install/scripts/install-cni.sh /install-cni.sh
 ADD k8s-install/scripts/calico.conf.default /calico.conf.tmp
 
-RUN mkdir /licenses
+RUN microdnf install hostname && mkdir /licenses
 COPY LICENSE /licenses
 
 ENV PATH=$PATH:/opt/cni/bin


### PR DESCRIPTION
In k8s, where the env var KUBERNETES_NODE_NAME is not set on the cni
container, we instead use the output of `hostname`.

The old base image `debian:slim` had `hostname` built-in but `ubi-minimal` doesn't. This PR adds that in.

This PR also pins the base image for consistency with our other dockerfiles.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

fixes #847 


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix missing hostname binary on ubi-minimal
```
