### PR TITLE
Automated cherry pick of #849: Use mv to put binaries on host

### DIFF
--- a/k8s-install/scripts/install-cni.sh
+++ b/k8s-install/scripts/install-cni.sh
@@ -89,7 +89,11 @@ do
       echo "$dir/$filename is already here and UPDATE_CNI_BINARIES isn't true, skipping"
       continue
     fi
-    cp "$path" $dir/ || exit_with_error "Failed to copy $path to $dir. This may be caused by selinux configuration on the host, or something else."
+    # Copy the binary to a temporary location, and then mv it into place. This safely
+    # distributes the binary even if the existing executable is currently running.
+    rm -f $dir/$filename.tmp
+    cp $path $dir/$filename.tmp
+    mv $dir/$filename.tmp $dir/$filename || exit_with_error "Failed to copy $dir/$filename.tmp to $dir/$filename. This may be caused by selinux configuration on the host, or something else."
   done
 
   echo "Wrote Calico CNI binaries to $dir"


### PR DESCRIPTION
Cherry pick of #849 on release-v3.13.

#849: Use mv to put binaries on host

```release-note 
Use mv to place CNI binaries instead of cp
```