### PR TITLE
Update base image to UBI in Dockerfile.ppc64le

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,4 +1,4 @@
-FROM ppc64le/debian:9.8-slim
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1-407
 
 LABEL maintainer "Casey Davenport <casey@tigera.io>"
 


### PR DESCRIPTION
Mirrors commit https://github.com/projectcalico/cni-plugin/commit/7070c4b96bd60ff9343aa5f81c7d2d64e81e2873 as well as changes made in master

The updated base image is required for a clean report from quay.io's security scan
https://quay.io/repository/calico/cni?tab=tags