### PR TITLE
Fix ppc64le Dockerfile

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,4 +1,5 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+# This is from registry.access.redhat.com/ubi8/ubi-minimal:8.2-267
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:7e432c89f285392c7d09343a3100e97158121bd5f73b89c852eba9609e19f9f4
 
 LABEL maintainer "Casey Davenport <casey@tigera.io>"
 


### PR DESCRIPTION
## Description

ubi-minimal is a multi-arch image. Need to specify the ppc64le manifest in the multi-arch base image otherwise the actual manifest used is determined by the system building the image. I think the only way to do that is by specifying the manifest by sha.

Need to pick to to release-v3.13 and release-v3.14.

Fixes #875 

```
laurence@user:~/go/src/github.com/projectcalico/cni-plugin$ manifest-tool inspect registry.access.redhat.com/ubi8/ubi-minimal:8.2-267
Name:   registry.access.redhat.com/ubi8/ubi-minimal:8.2-267 (Type: application/vnd.docker.distribution.manifest.list.v2+json)
Digest: sha256:326c94ab44d1472a30d47c49c2f896df687184830fc66a66de00c416885125b0
 * Contains 4 manifest references:
1    Mfst Type: application/vnd.docker.distribution.manifest.v2+json
1       Digest: sha256:fc7fc7bc6b293fd2ec1c1b035acc6b97ba34f0700c5366b699c646d947c39f81
1  Mfst Length: 737
1     Platform:
1           -      OS: linux
1           - OS Vers:
1           - OS Feat: []
1           -    Arch: amd64
1           - Variant:
1           - Feature:
1     # Layers: 2
         layer 1: digest = sha256:e96e3a1df3b2b1e01f9614725b50ea4d1d8e480980e456815ade3c7afca978d7
         layer 2: digest = sha256:1b99828eddf5297ca28fa7eac7f47a40d36a693c628311406788a14dfe75e076

2    Mfst Type: application/vnd.docker.distribution.manifest.v2+json
2       Digest: sha256:00308645ad3f0ee6384bffaab24d39b639c02742a536afa9aed97178e9654258
2  Mfst Length: 737
2     Platform:
2           -      OS: linux
2           - OS Vers:
2           - OS Feat: []
2           -    Arch: arm64
2           - Variant:
2           - Feature:
2     # Layers: 2
         layer 1: digest = sha256:89eba1daa7492f02d8f3559086eab072f9e4a3002936dd5aa93c2e4517be4ea4
         layer 2: digest = sha256:a3d418bf6534815fd6cc1398c2c38f4f1cde9ec472a96a604a9514e53587b8a5

3    Mfst Type: application/vnd.docker.distribution.manifest.v2+json
3       Digest: sha256:7e432c89f285392c7d09343a3100e97158121bd5f73b89c852eba9609e19f9f4
3  Mfst Length: 737
3     Platform:
3           -      OS: linux
3           - OS Vers:
3           - OS Feat: []
3           -    Arch: ppc64le
3           - Variant:
3           - Feature:
3     # Layers: 2
         layer 1: digest = sha256:84ede19b99598002e23de4c70698bb7631ee724fd537215476878141ce4c18c9
         layer 2: digest = sha256:b85e355b182585f0e146af4173b67fafaaea379ce5ac76aabe7462fffc374d2f

4    Mfst Type: application/vnd.docker.distribution.manifest.v2+json
4       Digest: sha256:7bb4dacb1e5fb5ad0742578d616982f836778fd0c5a0a00f843e9a7b1dabf487
4  Mfst Length: 737
4     Platform:
4           -      OS: linux
4           - OS Vers:
4           - OS Feat: []
4           -    Arch: s390x
4           - Variant:
4           - Feature:
4     # Layers: 2
         layer 1: digest = sha256:f519bc5bf3ce7084efc43646b12e7351c08df4681f58a7c309e65805bfc15899
         layer 2: digest = sha256:1e374ff45d724f97c9640ee55195d91ef4fa84375ca75e3a3aeef8374fd5f012
```


and

```
$ manifest-tool inspect registry.access.redhat.com/ubi8/ubi-minimal@sha256:7e432c89f285392c7d09343a3100e97158121bd5f73b89c852eba9609e19f9f4

registry.access.redhat.com/ubi8/ubi-minimal@sha256:7e432c89f285392c7d09343a3100e97158121bd5f73b89c852eba9609e19f9f4: manifest type: application/vnd.docker.distribution.manifest.v2+json
      Digest: sha256:7e432c89f285392c7d09343a3100e97158121bd5f73b89c852eba9609e19f9f4
Architecture: ppc64le
          OS: linux
    # Layers: 2
      layer 1: digest = sha256:84ede19b99598002e23de4c70698bb7631ee724fd537215476878141ce4c18c9
      layer 2: digest = sha256:b85e355b182585f0e146af4173b67fafaaea379ce5ac76aabe7462fffc374d2f

```
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix ppc64le by specifying the correct manifest for the arch
```
