### PR TITLE
namespaces support for mesos

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -317,7 +317,11 @@ func cmdAdd(args *skel.CmdArgs) error {
 				k := utils.SanitizeMesosLabel(label.Key)
 				v := utils.SanitizeMesosLabel(label.Value)
 
-				labels[k] = v
+				if label.Key == "projectcalico.org/namespace" {
+					wepIDs.Namespace = v
+				} else {
+					labels[k] = v
+				}
 			}
 
 			// 2) Create the endpoint object


### PR DESCRIPTION
## Description

Unlike k8s, Apache Mesos does not provide annotations, only labels.
This proposal is to use the `projectcalico.org/namespace` label value as namespace.


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note
