### PR TITLE
k8s-install: install-cni.sh now aborts when calico -v doesn't succeed

### DIFF
--- a/k8s-install/scripts/install-cni.sh
+++ b/k8s-install/scripts/install-cni.sh
@@ -97,7 +97,8 @@ do
   done
 
   echo "Wrote Calico CNI binaries to $dir"
-  echo "CNI plugin version: $($dir/calico -v)"
+  calico_version=$(${dir}/calico -v)
+  echo "CNI plugin version: ${calico_version}"
 done
 
 TMP_CONF='/calico.conf.tmp'


### PR DESCRIPTION
## Description
Fixes #877

Apparently echo masks the error. Can be reproduced with:

```bash
#!/usr/bin/env bash

set -e

echo "false in echo does not abort $(false)"

output=$(false)
echo "false in variable assignment does ${output}"
```

```release-note
install-cni.sh now also fails if `calico -v` doesn't work after copying the calico binary
```
