### PR TITLE
Remove flag windows_disable_host_subnet_nat_exclusion

### DIFF
--- a/internal/pkg/utils/network_linux.go
+++ b/internal/pkg/utils/network_linux.go
@@ -17,8 +17,12 @@ import (
 	"context"
 	"net"
 
+	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/sirupsen/logrus"
+
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/projectcalico/cni-plugin/pkg/types"
+	api "github.com/projectcalico/libcalico-go/lib/apis/v3"
 	calicoclient "github.com/projectcalico/libcalico-go/lib/clientv3"
 )
 
@@ -30,18 +34,14 @@ func EnsureVXLANTunnelAddr(ctx context.Context, calicoClient calicoclient.Interf
 	return nil
 }
 
-func NetworkApplicationContainer(args *skel.CmdArgs) error {
-	return nil
-}
-
-func MaintainWepDeletionTimestamps(timeout int) error {
-	return nil
-}
-
-func CheckWepJustDeleted(containerID string, timeout int) (bool, error) {
-	return false, nil
-}
-
 func RegisterDeletedWep(containerID string) error {
 	return nil
+}
+
+func CheckForSpuriousAdd(args *skel.CmdArgs,
+	conf types.NetConf,
+	epIDs WEPIdentifiers,
+	endpoint *api.WorkloadEndpoint,
+	logger *logrus.Entry) (*current.Result, error) {
+	return nil, nil
 }

--- a/internal/pkg/utils/winpol/windows_policy.go
+++ b/internal/pkg/utils/winpol/windows_policy.go
@@ -76,7 +76,7 @@ func CalculateEndpointPolicies(
 		}
 		outputPols = append(outputPols, outPol)
 	}
-	if !found && natOutgoing {
+	if !found && natOutgoing && len(extraNATExceptions) > 0 {
 		exceptions := appendCIDRs(nil, extraNATExceptions)
 		dict := map[string]interface{}{
 			"Type":          "OutBoundNAT",

--- a/pkg/dataplane/windows/dataplane_windows.go
+++ b/pkg/dataplane/windows/dataplane_windows.go
@@ -675,19 +675,6 @@ func (d *windowsDataplane) createAndAttachContainerEP(args *skel.CmdArgs,
 		return nil, fmt.Errorf("HNS network lost its management IP")
 	}
 
-	if natOutgoing {
-		d.logger.Debug("Looking up management subnet to add outgoing NAT exclusion.")
-		mgmtNet, err := lookupManagementAddr(mgmtIP, d.logger)
-		if err != nil {
-			return nil, err
-		}
-		if !d.conf.WindowsDisableHostSubnetNATExclusion {
-			natExclusions = make([]*net.IPNet, len(allIPAMPools)+1)
-			copy(natExclusions, allIPAMPools)
-			natExclusions[len(natExclusions)-1] = mgmtNet
-		}
-	}
-
 	pols, err := winpol.CalculateEndpointPolicies(n, natExclusions, natOutgoing, mgmtIP, d.logger)
 	if err != nil {
 		return nil, err

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -105,10 +105,6 @@ type NetConf struct {
 	// WindowsUseSingleNetwork disables the use of multiple IPAM blocks on a single host and forces
 	// a static HNS network name.
 	WindowsUseSingleNetwork bool `json:"windows_use_single_network,omitempty"`
-	// WindowsDisableHostSubnetNATExclusion disables our attempt to add an outbound NAT exclusion for the host's
-	// subnet.  The NAT exclusion is generally required for pod-to-host communication but that communication can also
-	// be enabled by manually setting an exclusion or by creating a dummy IP pool.
-	WindowsDisableHostSubnetNATExclusion bool `json:"windows_disable_host_subnet_nat_exclusion,omitempty"`
 	// WindowsDisableDefaultBlockAllPolicy disables the default "block all traffic" policy on the pod endpoint.
 	// By default, WindowsDisableDefaultBlockAllPolicy = false, as the default "block all traffic" policy is placed at
 	// the time of creating the pod network.


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
This PR
- Remove flag `windows_disable_host_subnet_nat_exclusion` so Calico `natOutGoing` has same effect on both Linux and Windows node.
- Refactor code for dealing with spurious add on Windows node.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
