### PR TITLE
Fix that CNI plugin itself was only being included if make ut was run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ update-pins: update-libcalico-pin
 # Building the binary
 ###############################################################################
 BIN=bin/$(ARCH)
-build: $(BIN)/install
+build: $(BIN)/install $(BIN)/calico $(BIN)/calico-ipam
 ifeq ($(ARCH),amd64)
 # Go only supports amd64 for Windows builds.
 BIN_WIN=bin/windows
@@ -207,11 +207,12 @@ sub-tag-images-%:
 # Unit Tests
 ###############################################################################
 ## Run the unit tests.
-ut: run-k8s-controller build $(BIN)/host-local
-	cp $(BIN)/install $(BIN)/calico-ipam
-	cp $(BIN)/install $(BIN)/calico
+ut: run-k8s-controller $(BIN)/install $(BIN)/host-local $(BIN)/calico-ipam $(BIN)/calico
 	$(MAKE) ut-datastore DATASTORE_TYPE=etcdv3
 	$(MAKE) ut-datastore DATASTORE_TYPE=kubernetes
+
+$(BIN)/calico-ipam $(BIN)/calico: $(BIN)/install
+	cp "$<" "$@"
 
 ut-datastore: $(LOCAL_BUILD_DEP)
 	# The tests need to run as root


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

The upgrade-ipam init container still runs `calico-ipam` but if you do a clean build with `make clean image` then that file doesn't get included.

After a bit of head scratching, I found that the `ut` target was copying that file into place so Semaphore's `make ci` included it in the image whereas `make image` doesn't.

Possible that we want to fix the manifest instead but thought it made sense to make the build sane if that file is meant to be included.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
