### PR TITLE
Fix release build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -384,8 +384,9 @@ endif
 
 	# Copy artifacts for upload to GitHub.
 	mkdir -p bin/github
-	$(foreach var,$(VALIDARCHES), cp bin/$(var)/calico bin/github/calico-$(var);)
-	$(foreach var,$(VALIDARCHES), cp bin/$(var)/calico-ipam bin/github/calico-ipam-$(var);)
+	$(foreach var,$(VALIDARCHES), cp bin/$(var)/install bin/github/install-$(var);)
+	cp bin/windows/calico.exe bin/github/calico.exe
+	cp bin/windows/calico-ipam.exe bin/github/calico-ipam.exe
 
 ## Verifies the release artifacts produces by `make release-build` are correct.
 release-verify: release-prereqs


### PR DESCRIPTION
## Description
```
# Copy artifacts for upload to GitHub.
mkdir -p bin/github
cp bin/amd64/calico bin/github/calico-amd64;  cp bin/arm64/calico bin/github/calico-arm64;  cp bin/ppc64le/calico bin/github/calico-ppc64le;
cp: cannot stat 'bin/amd64/calico': No such file or directory
cp: cannot stat 'bin/arm64/calico': No such file or directory
cp: cannot stat 'bin/ppc64le/calico': No such file or directory
Makefile:381: recipe for target 'release-build' failed
make[2]: *** [release-build] Error 1
make[2]: Leaving directory '/home/ubuntu/go/src/github.com/tigera/process/os/cni-plugin'
Makefile:356: recipe for target 'release' failed
make[1]: *** [release] Error 2
make[1]: Leaving directory '/home/ubuntu/go/src/github.com/tigera/process/os/cni-plugin'
Makefile:577: recipe for target 'cni-plugin-release' failed
make: *** [cni-plugin-release] Error 2

```
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
