### PR TITLE
Automated cherry pick of #948: Fix installation of etcd secrets into config file

### DIFF
--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -353,23 +353,22 @@ func writeCNIConfig(c config) {
 
 	// Replace etcd datastore variables.
 	hostSecretsDir := c.CNINetDir + "/calico-tls"
-
-	etcdCertFile := fmt.Sprintf("%s/etcd-cert", hostSecretsDir)
-	if fileExists(etcdCertFile) {
+	if fileExists("/host/etc/cni/net.d/calico-tls/etcd-cert") {
+		etcdCertFile := fmt.Sprintf("%s/etcd-cert", hostSecretsDir)
 		netconf = strings.Replace(netconf, "__ETCD_CERT_FILE__", etcdCertFile, -1)
 	} else {
 		netconf = strings.Replace(netconf, "__ETCD_CERT_FILE__", "", -1)
 	}
 
-	etcdCACertFile := fmt.Sprintf("%s/etcd-ca", hostSecretsDir)
-	if fileExists(etcdCACertFile) {
+	if fileExists("/host/etc/cni/net.d/calico-tls/etcd-ca") {
+		etcdCACertFile := fmt.Sprintf("%s/etcd-ca", hostSecretsDir)
 		netconf = strings.Replace(netconf, "__ETCD_CA_CERT_FILE__", etcdCACertFile, -1)
 	} else {
 		netconf = strings.Replace(netconf, "__ETCD_CA_CERT_FILE__", "", -1)
 	}
 
-	etcdKeyFile := fmt.Sprintf("%s/etcd-key", hostSecretsDir)
-	if fileExists(etcdKeyFile) {
+	if fileExists("/host/etc/cni/net.d/calico-tls/etcd-key") {
+		etcdKeyFile := fmt.Sprintf("%s/etcd-key", hostSecretsDir)
 		netconf = strings.Replace(netconf, "__ETCD_KEY_FILE__", etcdKeyFile, -1)
 	} else {
 		netconf = strings.Replace(netconf, "__ETCD_KEY_FILE__", "", -1)

--- a/pkg/install/install_test.go
+++ b/pkg/install/install_test.go
@@ -240,12 +240,16 @@ PuB/TL+u2y+iQUyXxLy3
 		It("Should copy a non-hidden file", func() {
 			err = ioutil.WriteFile(tempDir+"/certs/etcd-cert", []byte("doesn't matter"), 0644)
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to write file: %v", err))
-			err = runCniContainer(tempDir, "-v", tempDir+"/certs:/calico-secrets")
+			err = runCniContainer(tempDir, "-v", tempDir+"/certs:/calico-secrets", "-e", "CNI_NETWORK_CONFIG={\"etcd_cert\": \"__ETCD_CERT_FILE__\"}")
 			Expect(err).NotTo(HaveOccurred())
 			file, err := os.Open(tempDir + "/net.d/calico-tls/etcd-cert")
 			Expect(err).NotTo(HaveOccurred())
 			err = file.Close()
 			Expect(err).NotTo(HaveOccurred())
+
+			// Expect the config to have the correct value filled in.
+			expectedConfig := "{\"etcd_cert\": \"/etc/cni/net.d/calico-tls/etcd-cert\"}"
+			expectFileContents(tempDir+"/net.d/10-calico.conflist", expectedConfig)
 		})
 	})
 })


### PR DESCRIPTION
Cherry pick of #948 on release-v3.16.

#948: Fix installation of etcd secrets into config file

```release-note
Fix population of etcd certificates in CNI config
```