### PR TITLE
Create l2bridge without DNS info

### DIFF
--- a/internal/pkg/testutils/utils_windows.go
+++ b/internal/pkg/testutils/utils_windows.go
@@ -335,8 +335,6 @@ func CreateNetwork(netconf string) (*hcsshim.HNSNetwork, error) {
 		panic(err)
 	}
 
-	result := &current.Result{}
-
 	_, subNet, _ := net.ParseCIDR(conf.IPAM.Subnet)
 
 	var logger *log.Entry
@@ -352,7 +350,7 @@ func CreateNetwork(netconf string) (*hcsshim.HNSNetwork, error) {
 		networkName = windows.CreateNetworkName(conf.Name, subNet)
 	}
 
-	hnsNetwork, err := windows.EnsureNetworkExists(networkName, subNet, result.DNS, logger)
+	hnsNetwork, err := windows.EnsureNetworkExists(networkName, subNet, logger)
 	if err != nil {
 		logger.Errorf("Unable to create hns network %s", networkName)
 		return nil, err

--- a/pkg/dataplane/windows/dataplane_windows.go
+++ b/pkg/dataplane/windows/dataplane_windows.go
@@ -27,7 +27,6 @@ import (
 	"github.com/Microsoft/hcsshim/hcn"
 	"github.com/buger/jsonparser"
 	"github.com/containernetworking/cni/pkg/skel"
-	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/plugins/pkg/hns"
 	"github.com/juju/clock"
@@ -85,8 +84,8 @@ func acquireLock() (mutex.Releaser, error) {
 	return m, nil
 }
 
-func SetupL2bridgeNetwork(networkName string, subNet *net.IPNet, dns cnitypes.DNS, logger *logrus.Entry) (*hcsshim.HNSNetwork, error) {
-	hnsNetwork, err := EnsureNetworkExists(networkName, subNet, dns, logger)
+func SetupL2bridgeNetwork(networkName string, subNet *net.IPNet, logger *logrus.Entry) (*hcsshim.HNSNetwork, error) {
+	hnsNetwork, err := EnsureNetworkExists(networkName, subNet, logger)
 	if err != nil {
 		logger.Errorf("Unable to create hns network %s", networkName)
 		return nil, err
@@ -194,7 +193,7 @@ func (d *windowsDataplane) DoNetworking(
 	if d.conf.Mode == "vxlan" {
 		hnsNetwork, err = SetupVxlanNetwork(networkName, subNet, d.conf.VXLANVNI, d.logger)
 	} else {
-		hnsNetwork, err = SetupL2bridgeNetwork(networkName, subNet, result.DNS, d.logger)
+		hnsNetwork, err = SetupL2bridgeNetwork(networkName, subNet, d.logger)
 	}
 	if err != nil {
 		d.logger.Errorf("Unable to create hns network %s", networkName)
@@ -385,7 +384,7 @@ func ensureVxlanNetworkExists(networkName string, subNet *net.IPNet, vni uint64,
 	return existingNetwork, nil
 }
 
-func EnsureNetworkExists(networkName string, subNet *net.IPNet, dns cnitypes.DNS, logger *logrus.Entry) (*hcsshim.HNSNetwork, error) {
+func EnsureNetworkExists(networkName string, subNet *net.IPNet, logger *logrus.Entry) (*hcsshim.HNSNetwork, error) {
 	var err error
 	createNetwork := true
 	addressPrefix := subNet.String()
@@ -423,8 +422,6 @@ func EnsureNetworkExists(networkName string, subNet *net.IPNet, dns cnitypes.DNS
 					"GatewayAddress": gatewayAddress,
 				},
 			},
-			"DNSServerList": strings.Join(dns.Nameservers, ","),
-			"DNSSuffix":     strings.Join(dns.Search, ","),
 		}
 
 		reqStr, err := json.Marshal(req)

--- a/win_tests/calico_cni_k8s_windows_test.go
+++ b/win_tests/calico_cni_k8s_windows_test.go
@@ -994,8 +994,6 @@ var _ = Describe("Kubernetes CNI tests", func() {
 					Expect(hnsNetwork.Subnets[0].AddressPrefix).Should(Equal("10.254.112.0/20"))
 					Expect(hnsNetwork.Subnets[0].GatewayAddress).Should(Equal("10.254.112.1"))
 					Expect(hnsNetwork.Type).Should(Equal("L2Bridge"))
-					Expect(hnsNetwork.DNSSuffix).Should(Equal("pod.cluster.local"))
-					Expect(hnsNetwork.DNSServerList).Should(Equal("10.96.0.10"))
 
 					// Ensure host and container endpoints are created
 					hostEP, err := hcsshim.GetHNSEndpointByName("calico-fv_ep")
@@ -1004,8 +1002,6 @@ var _ = Describe("Kubernetes CNI tests", func() {
 					Expect(hostEP.IPAddress.String()).Should(Equal("10.254.112.2"))
 					Expect(hostEP.VirtualNetwork).Should(Equal(hnsNetwork.Id))
 					Expect(hostEP.VirtualNetworkName).Should(Equal(hnsNetwork.Name))
-					Expect(hostEP.DNSSuffix).Should(Equal("pod.cluster.local"))
-					Expect(hostEP.DNSServerList).Should(Equal("10.96.0.10"))
 
 					containerEP, err := hcsshim.GetHNSEndpointByName(containerID + "_calico-fv")
 					Expect(containerEP.GatewayAddress).Should(Equal("10.254.112.2"))
@@ -1656,17 +1652,13 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(endpoints.Items).Should(HaveLen(1))
 
-				// Ensure network is created and has DNS RuntimeConfig values
-				hnsNetwork, err := hcsshim.GetHNSNetworkByName(networkName)
+				// Ensure network is created.
+				_, err = hcsshim.GetHNSNetworkByName(networkName)
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(hnsNetwork.DNSSuffix).Should(Equal("svc.cluster.local"))
-				Expect(hnsNetwork.DNSServerList).Should(Equal("10.96.0.11"))
 
-				// Ensure host endpoints are created and has DNS RuntimeConfig values
-				hostEP, err := hcsshim.GetHNSEndpointByName("calico-fv_ep")
+				// Ensure host endpoints are created
+				_, err = hcsshim.GetHNSEndpointByName("calico-fv_ep")
 				Expect(err).ShouldNot(HaveOccurred())
-				Expect(hostEP.DNSSuffix).Should(Equal("svc.cluster.local"))
-				Expect(hostEP.DNSServerList).Should(Equal("10.96.0.11"))
 
 				// Ensure container endpoints are created and has DNS RuntimeConfig values
 				containerEP, err := hcsshim.GetHNSEndpointByName(containerID + "_calico-fv")


### PR DESCRIPTION
Remove passing DNS information for creating l2bridge. This would allow calico-node to create calico network.
(cherry picked from commit 09bdb92807d5637bf67187bf329ea81df963baa7)



## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
