### PR TITLE
Fix error message in IP assignment which references the field it failed to set

### DIFF
--- a/pkg/upgrade/migrate.go
+++ b/pkg/upgrade/migrate.go
@@ -111,7 +111,7 @@ func Migrate(ctxt context.Context, c client.Interface, nodename string) error {
 				},
 			}); err != nil {
 				if _, ok := err.(errors.ErrorResourceAlreadyExists); !ok {
-					return fmt.Errorf("failed to get add IPIP tunnel addr %s: %s", node.Spec.BGP.IPv4IPIPTunnelAddr, err)
+					return fmt.Errorf("failed to get add IPIP tunnel addr %s: %s", tunIp.String(), err)
 				}
 				log.Info("IPIP tunnel address already assigned in IPAM, continuing...")
 			}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Fixes https://github.com/projectcalico/calico/issues/3749 . This was causing a nil pointer exception since the BGP spec may not exist if the tunnel IP assignment fails.



## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fixes a bug that caused IPAM assignment to throw a nil pointer exception in cases where tunnel address IP assignment failed.
```
