### PR TITLE
Fix update CNI binary logic

### DIFF
--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -49,7 +49,7 @@ type config struct {
 
 	// UpdateCNIBinaries controls whether or not to overwrite any binaries with the same name
 	// on the host.
-	UpdateCNIBinaries bool `envconfig:"UPDATE_CNI_BINARIES"`
+	UpdateCNIBinaries bool `envconfig:"UPDATE_CNI_BINARIES" default:"true"`
 
 	// The CNI network configuration to install.
 	CNINetworkConfig     string `envconfig:"CNI_NETWORK_CONFIG"`
@@ -201,7 +201,7 @@ func Install() error {
 			if c.skipBinary(binary.Name()) {
 				continue
 			}
-			if fileExists(target) && c.UpdateCNIBinaries {
+			if fileExists(target) && !c.UpdateCNIBinaries {
 				logrus.Infof("Skipping installation of %s", target)
 				continue
 			}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Fixes a logical error pointed out in https://github.com/projectcalico/cni-plugin/issues/957 that changed the behavior of the `UPDATE_CNI_BINARIES` env variable. The actual fix for the above issue that relates to the symlink is fixed by https://github.com/projectcalico/cni-plugin/pull/966.

This was tested by setting the `UPDATE_CNI_BINARIES` values and making sure that the binaries were overwritten (or not depending on the value) when they were not expected to when the pods were restarted.


## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix a bug that made the UPDATE_CNI_BINARIES environment variable not behave as expected.
```
