### PR TITLE
Automated cherry pick of #995: Fix make cd target to use correct tag for docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -347,7 +347,7 @@ ifndef BRANCH_NAME
 	$(error BRANCH_NAME is undefined - run using make <target> BRANCH_NAME=var or set an environment variable)
 endif
 	$(MAKE) tag-images-all push-all push-manifests push-non-manifests  IMAGETAG=${BRANCH_NAME} EXCLUDEARCH="$(EXCLUDEARCH)"
-	$(MAKE) tag-images-all push-all push-manifests push-non-manifests  IMAGETAG=${GIT_VERSION} EXCLUDEARCH="$(EXCLUDEARCH)"
+	$(MAKE) tag-images-all push-all push-manifests push-non-manifests  IMAGETAG=$(shell git describe --tags --dirty --always --long --abbrev=12) EXCLUDEARCH="$(EXCLUDEARCH)"
 
 ## Build fv binary for Windows
 $(BIN_WIN)/win-fv.exe: $(LOCAL_BUILD_DEP) $(WINFV_SRCFILES)


### PR DESCRIPTION
Cherry pick of #995 on release-v3.17.

#995: Fix make cd target to use correct tag for docker images