### PR TITLE
Make sure we log out a final error from CNI ADD/DEL.

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -115,6 +115,9 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 			}
 			err = fmt.Errorf(msg)
 		}
+		if err != nil {
+			logrus.WithError(err).Error("Final result of CNI ADD was an error.")
+		}
 	}()
 
 	// Unmarshal the network config, and perform validation
@@ -505,6 +508,9 @@ func cmdDel(args *skel.CmdArgs) (err error) {
 				msg = fmt.Sprintf("%s: error=%s", msg, err)
 			}
 			err = fmt.Errorf(msg)
+		}
+		if err != nil {
+			logrus.WithError(err).Error("Final result of CNI DEL was an error.")
 		}
 	}()
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

If we just return the error then we have to correlate problems with the CNI client's log (if there is one).  Make sure that we log our final error result into our own log.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Ensure the CNI plugin logs out an error to its own log rather than relying on the CNI client to log out final errors.
```
