### PR TITLE
Fix ipam migration datastore lock 3.17

### DIFF
--- a/pkg/upgrade/migrate.go
+++ b/pkg/upgrade/migrate.go
@@ -344,7 +344,7 @@ func Migrate(ctxt context.Context, c client.Interface, nodename string) error {
 	calicoDS, err := k8sClient.AppsV1().DaemonSets("kube-system").Get("calico-node", metav1.GetOptions{})
 	if err != nil {
 		log.WithError(err).Error("failed to retrieve Calico daemonset to check if datastore readiness should be set to true")
-	} else if calicoDS.Status.UpdatedNumberScheduled == calicoDS.Status.DesiredNumberScheduled-calicoDS.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable.IntVal {
+	} else if calicoDS.Status.UpdatedNumberScheduled >= calicoDS.Status.DesiredNumberScheduled-calicoDS.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable.IntVal {
 		log.Info("setting Calico datastore readiness to true...")
 		t := true
 		clusterInfo.Spec.DatastoreReady = &t

--- a/pkg/upgrade/migrate.go
+++ b/pkg/upgrade/migrate.go
@@ -344,7 +344,7 @@ func Migrate(ctxt context.Context, c client.Interface, nodename string) error {
 	calicoDS, err := k8sClient.AppsV1().DaemonSets("kube-system").Get("calico-node", metav1.GetOptions{})
 	if err != nil {
 		log.WithError(err).Error("failed to retrieve Calico daemonset to check if datastore readiness should be set to true")
-	} else if calicoDS.Status.UpdatedNumberScheduled >= calicoDS.Status.DesiredNumberScheduled-calicoDS.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable.IntVal {
+	} else if calicoDS.Status.UpdatedNumberScheduled == calicoDS.Status.DesiredNumberScheduled {
 		log.Info("setting Calico datastore readiness to true...")
 		t := true
 		clusterInfo.Spec.DatastoreReady = &t

--- a/pkg/upgrade/migrate.go
+++ b/pkg/upgrade/migrate.go
@@ -338,21 +338,20 @@ func Migrate(ctxt context.Context, c client.Interface, nodename string) error {
 		log.Info("successfully released lock on host-local backend!")
 	}
 
-	// Re-enable datastoreReady if this is the last node to update. We know this is the last
-	// node to update if the number of UpdatedNumberScheduled is MaxUnavailable less than the
-	// DesiredNumberScheduled.
-	calicoDS, err := k8sClient.AppsV1().DaemonSets("kube-system").Get("calico-node", metav1.GetOptions{})
-	if err != nil {
-		log.WithError(err).Error("failed to retrieve Calico daemonset to check if datastore readiness should be set to true")
-	} else if calicoDS.Status.UpdatedNumberScheduled == calicoDS.Status.DesiredNumberScheduled {
-		log.Info("setting Calico datastore readiness to true...")
-		t := true
-		clusterInfo.Spec.DatastoreReady = &t
-		if _, err = c.ClusterInformation().Update(ctxt, clusterInfo, options.SetOptions{}); err != nil {
-			return fmt.Errorf("failed to re-enable cluster: %s", err)
-		}
-		log.Info("successfully set Calico datastore readiness to true!")
+	// Always re-enable datastoreReady. This leaves a very small chance that an address may be assigned by calico-ipam
+	// that is already in use by host-local. Any pods stuck in this situation will be fixed once they are restarted.
+	// TODO: Re-enable datastoreReady if all of the nodes have been picked up for the rolling update.
+	// This logic has not been used because of the potential length of time it would bring normal operation
+	// of the cluster down for by locking the datastore until the update has been applied to all nodes.
+	// calicoDS, err := k8sClient.AppsV1().DaemonSets("kube-system").Get(context.Background(), "calico-node", metav1.GetOptions{})
+	// if calicoDS.Status.UpdatedNumberScheduled == calicoDS.Status.DesiredNumberScheduled {
+	log.Info("setting Calico datastore readiness to true...")
+	t := true
+	clusterInfo.Spec.DatastoreReady = &t
+	if _, err = c.ClusterInformation().Update(ctxt, clusterInfo, options.SetOptions{}); err != nil {
+		return fmt.Errorf("failed to re-enable cluster: %s", err)
 	}
+	log.Info("successfully set Calico datastore readiness to true!")
 
 	// Delete the host-local IPAM data directory.
 	log.Info("removing host-local IPAM data directory")


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Cherry-pick of https://github.com/projectcalico/cni-plugin/pull/1013


## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix a bug that prevented datastore readiness from being reset during IPAM migration.
```
