### PR TITLE
Remove route encap policy for endpoint

### DIFF
--- a/internal/pkg/utils/winpol/windows_policy.go
+++ b/internal/pkg/utils/winpol/windows_policy.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2018-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -90,21 +90,6 @@ func CalculateEndpointPolicies(
 
 		outputPols = append(outputPols, json.RawMessage(encoded))
 	}
-
-	// Add an entry to force encap to the management IP.  We think this is required for node ports.  The encap is
-	// local to the host so there's no real vxlan going on here.
-	dict := map[string]interface{}{
-		"Type":              "ROUTE",
-		"DestinationPrefix": mgmtIP.String() + "/32",
-		"NeedEncap":         true,
-	}
-	encoded, err := json.Marshal(dict)
-	if err != nil {
-		logger.WithError(err).Error("Failed to add outbound NAT exclusion.")
-		return nil, err
-	}
-
-	outputPols = append(outputPols, json.RawMessage(encoded))
 
 	return outputPols, nil
 }

--- a/internal/pkg/utils/winpol/windows_policy_test.go
+++ b/internal/pkg/utils/winpol/windows_policy_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2018-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -51,7 +51,6 @@ func TestCalculateEndpointPolicies(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(pols).To(Equal([]json.RawMessage{
 		json.RawMessage(`{"Type": "SomethingElse"}`),
-		json.RawMessage(`{"DestinationPrefix":"10.11.128.13/32","NeedEncap":true,"Type":"ROUTE"}`),
 	}), "OutBoundNAT should have been filtered out")
 
 	t.Log("With NAT enabled, OutBoundNAT should be augmented")
@@ -60,7 +59,6 @@ func TestCalculateEndpointPolicies(t *testing.T) {
 	Expect(pols).To(Equal([]json.RawMessage{
 		json.RawMessage(`{"ExceptionList":["10.96.0.0/12","10.0.1.0/24","10.0.2.0/24","10.11.128.0/19"],"Type":"OutBoundNAT"}`),
 		json.RawMessage(`{"Type": "SomethingElse"}`),
-		json.RawMessage(`{"DestinationPrefix":"10.11.128.13/32","NeedEncap":true,"Type":"ROUTE"}`),
 	}))
 
 	t.Log("With NAT enabled, and no OutBoundNAT stanza, OutBoundNAT should be added")
@@ -72,7 +70,6 @@ func TestCalculateEndpointPolicies(t *testing.T) {
 	Expect(pols).To(Equal([]json.RawMessage{
 		json.RawMessage(`{"Type": "SomethingElse"}`),
 		json.RawMessage(`{"ExceptionList":["10.0.1.0/24","10.0.2.0/24","10.11.128.0/19"],"Type":"OutBoundNAT"}`),
-		json.RawMessage(`{"DestinationPrefix":"10.11.128.13/32","NeedEncap":true,"Type":"ROUTE"}`),
 	}))
 
 	t.Log("With NAT disabled, and no OutBoundNAT stanza, OutBoundNAT should not be added")
@@ -80,7 +77,6 @@ func TestCalculateEndpointPolicies(t *testing.T) {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(pols).To(Equal([]json.RawMessage{
 		json.RawMessage(`{"Type": "SomethingElse"}`),
-		json.RawMessage(`{"DestinationPrefix":"10.11.128.13/32","NeedEncap":true,"Type":"ROUTE"}`),
 	}))
 }
 

--- a/pkg/dataplane/windows/dataplane_windows.go
+++ b/pkg/dataplane/windows/dataplane_windows.go
@@ -693,6 +693,11 @@ func (d *windowsDataplane) createAndAttachContainerEP(args *skel.CmdArgs,
 		}
 		// conjure a MAC based on the IP for Overlay
 		macAddr = fmt.Sprintf("%v-%02x-%02x-%02x-%02x", vxlanMACPrefix, epIPBytes[0], epIPBytes[1], epIPBytes[2], epIPBytes[3])
+
+		pols = append(pols, []json.RawMessage{
+			[]byte(fmt.Sprintf(`{"Type":"PA","PA":"%s"}`, hnsNetwork.ManagementIP)),
+		}...)
+
 	}
 
 	attempts := 3


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Revert changes made by https://github.com/projectcalico/cni-plugin/pull/1011  and add PA route for Windows endpoint.
Remove route policy for Windows endpoint instead because this breaks vxlan host to local pod access.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
