### PR TITLE
Fix network id comparision for Windows OS 2004

### DIFF
--- a/pkg/dataplane/windows/dataplane_windows.go
+++ b/pkg/dataplane/windows/dataplane_windows.go
@@ -546,9 +546,12 @@ func CreateAndAttachHostEP(epName string, hnsNetwork *hcsshim.HNSNetwork, subNet
 			}
 			logger.Infof("Deleted stale bridge endpoint [%v]")
 			hnsEndpoint = nil
-		} else if hnsEndpoint.VirtualNetwork == hnsNetwork.Id {
+		} else if strings.ToUpper(hnsEndpoint.VirtualNetwork) == strings.ToUpper(hnsNetwork.Id) {
 			// Endpoint exists for correct network. No processing required
 			attachEndpoint = false
+		} else {
+			logger.Errorf("HnsEndpoint virtual network %s not matching ID %s",
+				hnsEndpoint.VirtualNetwork, hnsNetwork.Id)
 		}
 	}
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

On Windows OS 2004, VirtualNetwork of a Calico_ep endpoint has lower case of Calico network ID. This cause errors if Calico CNI compare IDs in their original format.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
