### PR TITLE
Add armv7 build

### DIFF
--- a/Dockerfile.armv7
+++ b/Dockerfile.armv7
@@ -1,0 +1,12 @@
+FROM scratch
+
+ADD licenses/ /licenses
+ADD LICENSE /licenses/
+
+LABEL maintainer "maintainers@projectcalico.org"
+
+ADD bin/armv7 /opt/cni/bin/
+
+ENV PATH=$PATH:/opt/cni/bin
+WORKDIR /opt/cni/bin
+CMD ["/opt/cni/bin/install"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PACKAGE_NAME=github.com/projectcalico/cni-plugin
-GO_BUILD_VER=v0.51
+GO_BUILD_VER=v0.52
 
 # This needs to be evaluated before the common makefile is included.
 # This var contains some default values that the common makefile may append to.
@@ -88,6 +88,16 @@ ifeq ($(ARCH),amd64)
 BIN_WIN=bin/windows
 build: $(BIN_WIN)/calico.exe $(BIN_WIN)/calico-ipam.exe
 endif
+# If ARCH is arm based, find the requested version/variant
+ifeq ($(word 1,$(subst v, ,$(ARCH))),arm)
+ARM_VERSION := $(word 2,$(subst v, ,$(ARCH)))
+endif
+# Define go architecture flags to support arm variants
+GOARCH_FLAGS :=-e GOARCH=$(ARCH)
+ifdef ARM_VERSION
+GOARCH_FLAGS :=-e GOARCH=arm -e GOARM=$(ARM_VERSION)
+endif
+
 build-all: $(addprefix sub-build-,$(VALIDARCHES))
 sub-build-%:
 	$(MAKE) build ARCH=$*
@@ -98,7 +108,7 @@ $(BIN)/install binary: $(SRC_FILES)
 	-mkdir -p $(BIN)
 	$(DOCKER_RUN) \
 	-e ARCH=$(ARCH) \
-	-e GOARCH=$(ARCH) \
+	$(GOARCH_FLAGS) \
 	-e LOCAL_USER_ID=$(LOCAL_USER_ID) \
 	-v $(CURDIR):/go/src/$(PACKAGE_NAME):rw \
 	-v $(CURDIR)/$(BIN):/go/src/$(PACKAGE_NAME)/$(BIN):rw \
@@ -138,7 +148,7 @@ fetch-cni-bins: $(BIN)/flannel $(BIN)/loopback $(BIN)/host-local $(BIN)/portmap 
 
 $(BIN)/flannel $(BIN)/loopback $(BIN)/host-local $(BIN)/portmap $(BIN)/tuning $(BIN)/bandwidth:
 	mkdir -p $(BIN)
-	$(CURL) -L --retry 5 https://github.com/containernetworking/plugins/releases/download/$(CNI_VERSION)/cni-plugins-linux-$(ARCH)-$(CNI_VERSION).tgz | tar -xz -C $(BIN) ./flannel ./loopback ./host-local ./portmap ./tuning ./bandwidth
+	$(CURL) -L --retry 5 https://github.com/containernetworking/plugins/releases/download/$(CNI_VERSION)/cni-plugins-linux-$(subst v7,,$(ARCH))-$(CNI_VERSION).tgz | tar -xz -C $(BIN) ./flannel ./loopback ./host-local ./portmap ./tuning ./bandwidth
 
 ###############################################################################
 # Unit Tests


### PR DESCRIPTION
## Description
- Allow to build the cni-plugin for armv7 architecture
- This is one of many PR for [armv7 support for calico](https://github.com/projectcalico/calico/issues/3583)
- Tests: built and tested locally

## Todos
- [ ] Tests
- [x] Release note

## Release Note

```release-note
None required
```
