### PR TITLE
Extend semaphore job timeout to 2 hours

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,5 +1,9 @@
 version: v1.0
 name: CNIPlugin
+
+execution_time_limit:
+  hours: 2
+
 agent:
   machine:
     type: e1-standard-2


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

Windows FV job could takes more than 36 minutes. Leave some room for queueing as well.  Sometimes WinFV job is pending on the queue but the timeout clock is still ticking.


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
