### PR TITLE
Simplify cni installation

### DIFF
--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -169,14 +169,6 @@ func Install() error {
 		}
 	}
 
-	// Copy install to calico and calico-ipam
-	if err := copyFileAndPermissions("/opt/cni/bin/install", "/opt/cni/bin/calico"); err != nil {
-		logrus.WithError(err).Fatalf("Failed to copy install to calico")
-	}
-	if err := copyFileAndPermissions("/opt/cni/bin/install", "/opt/cni/bin/calico-ipam"); err != nil {
-		logrus.WithError(err).Fatalf("Failed to copy install to calico-ipam")
-	}
-
 	// Place the new binaries if the directory is writeable.
 	dirs := []string{"/host/opt/cni/bin", "/host/secondary-bin-dir"}
 	for _, d := range dirs {
@@ -193,11 +185,6 @@ func Install() error {
 		for _, binary := range files {
 			target := fmt.Sprintf("%s/%s", d, binary.Name())
 			source := fmt.Sprintf("/opt/cni/bin/%s", binary.Name())
-			if strings.Contains(binary.Name(), "calico") {
-				// For Calico binaries, we copy over the install binary. It includes the code
-				// for each, and the name of the binary determined which is executed.
-				source = "/opt/cni/bin/install"
-			}
 			if c.skipBinary(binary.Name()) {
 				continue
 			}


### PR DESCRIPTION
As the `calico` and `calico-ipam` are included in the container image next to the `install` binary, there is no need to copy them in the container.
It is also not necessary to have special logic to copy the `install` binary instead of the `calico` and `calico-ipam` binaries.
The resulting installation logic is easier to understand.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

This pull request makes the `Install()` function easier to understand by removing unnecessary/redundant operations. It becomes easier to reason about what is happening when unnecessary operations are no longer present.

I tested the fix manually with manually build container images.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
