### PR TITLE
windows: Remove assertion that fails when container creation is slow

### DIFF
--- a/win_tests/calico_cni_k8s_windows_test.go
+++ b/win_tests/calico_cni_k8s_windows_test.go
@@ -2099,9 +2099,6 @@ var _ = Describe("Kubernetes CNI tests", func() {
 
 			_, err = testutils.GetTimestampValue(utils.PodDeletedKey, containerID2)
 			Expect(err).Should(HaveOccurred())
-
-			_, err = testutils.GetTimestampValue(utils.PodDeletedKey, containerID3)
-			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
## Description

Remove flakey assertion in windows FV test.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
