### PR TITLE
windows: update EnsureVXLANTunnelAddr so we can call it from node

### DIFF
--- a/internal/pkg/utils/network_linux.go
+++ b/internal/pkg/utils/network_linux.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020 Tigera, Inc. All rights reserved.
+// Copyright (c) 2018-2021 Tigera, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ func updateHostLocalIPAMDataForOS(subnet string, ipamData map[string]interface{}
 	return nil
 }
 
-func EnsureVXLANTunnelAddr(ctx context.Context, calicoClient calicoclient.Interface, nodeName string, ipNet *net.IPNet, conf types.NetConf) error {
+func EnsureVXLANTunnelAddr(ctx context.Context, calicoClient calicoclient.Interface, nodeName string, ipNet *net.IPNet, networkName string) error {
 	return nil
 }
 

--- a/internal/pkg/utils/network_windows.go
+++ b/internal/pkg/utils/network_windows.go
@@ -47,8 +47,8 @@ func updateHostLocalIPAMDataForOS(subnet string, ipamData map[string]interface{}
 	return UpdateHostLocalIPAMDataForWindows(subnet, ipamData)
 }
 
-func EnsureVXLANTunnelAddr(ctx context.Context, calicoClient calicoclient.Interface, nodeName string, ipNet *net.IPNet, conf types.NetConf) error {
-	return windows.EnsureVXLANTunnelAddr(ctx, calicoClient, nodeName, ipNet, conf)
+func EnsureVXLANTunnelAddr(ctx context.Context, calicoClient calicoclient.Interface, nodeName string, ipNet *net.IPNet, networkName string) error {
+	return windows.EnsureVXLANTunnelAddr(ctx, calicoClient, nodeName, ipNet, networkName)
 }
 
 func networkApplicationContainer(args *skel.CmdArgs) error {

--- a/pkg/dataplane/windows/dataplane_windows.go
+++ b/pkg/dataplane/windows/dataplane_windows.go
@@ -471,7 +471,7 @@ func EnsureNetworkExists(networkName string, subNet *net.IPNet, logger *logrus.E
 	return hnsNetwork, err
 }
 
-func EnsureVXLANTunnelAddr(ctx context.Context, calicoClient calicoclient.Interface, nodeName string, ipNet *net.IPNet, conf types.NetConf) error {
+func EnsureVXLANTunnelAddr(ctx context.Context, calicoClient calicoclient.Interface, nodeName string, ipNet *net.IPNet, networkName string) error {
 	logrus.Debug("Checking the node's VXLAN tunnel address")
 	var updateRequired bool
 	node, err := calicoClient.Nodes().Get(ctx, nodeName, options.GetOptions{})
@@ -483,13 +483,6 @@ func EnsureVXLANTunnelAddr(ctx context.Context, calicoClient calicoclient.Interf
 	if node.Spec.IPv4VXLANTunnelAddr != expectedIP {
 		logrus.WithField("ip", expectedIP).Debug("VXLAN tunnel IP to be updated")
 		updateRequired = true
-	}
-
-	var networkName string
-	if conf.WindowsUseSingleNetwork {
-		networkName = conf.Name
-	} else {
-		networkName = CreateNetworkName(conf.Name, ipNet)
 	}
 
 	mac, err := GetDRMACAddr(networkName, ipNet)

--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -406,7 +406,7 @@ func CmdAddK8s(ctx context.Context, args *skel.CmdArgs, conf types.NetConf, epID
 		_, subNet, _ := net.ParseCIDR(result.IPs[0].Address.String())
 		var err error
 		for attempts := 3; attempts > 0; attempts-- {
-			err = utils.EnsureVXLANTunnelAddr(ctx, calicoClient, epIDs.Node, subNet, conf)
+			err = utils.EnsureVXLANTunnelAddr(ctx, calicoClient, epIDs.Node, subNet, conf.Name)
 			if err != nil {
 				logger.WithError(err).Warn("Failed to set node's VXLAN tunnel IP, node may not receive traffic.  May retry...")
 				time.Sleep(1 * time.Second)


### PR DESCRIPTION
## Description

This PR updates EnsureVXLANTunnelAddr so it can be called from node during startup.

<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->



## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
