### PR TITLE
create multi queue veth for xdp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/rakelkar/gonetsh v0.0.0-20190930180311-e5c5ffe4bdf0
 	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.4.2
-	github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf
+	github.com/vishvananda/netlink v1.1.1-0.20210703095558-21f2c55a7727
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20201125193152-8a03d2e9614b
 	golang.org/x/net v0.0.0-20210224082022-3d97a244fca7
 	golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073

--- a/go.sum
+++ b/go.sum
@@ -503,8 +503,15 @@ github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf h1:3J37+NPjNyGW/dbfXtj3yWuF9OEepIdGOXRaJGbORV8=
 github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
+github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
+github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
+github.com/vishvananda/netlink v1.1.1-0.20210703095558-21f2c55a7727 h1:ocCC8f9ic0JubgwloXlpNYXxn3twdQ8ERel0jqH8rmw=
+github.com/vishvananda/netlink v1.1.1-0.20210703095558-21f2c55a7727/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc h1:R83G5ikgLMxrBvLh22JhdfI8K6YXEPHx5P03Uu3DRs4=
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
+github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae h1:4hwBBUfQCFe3Cym0ZtKyq7L16eZUtYKs+BaHDN6mAns=
+github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -645,6 +652,7 @@ golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190514135907-3a4b5fb9f71f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -664,10 +672,12 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/dataplane/linux/dataplane_linux.go
+++ b/pkg/dataplane/linux/dataplane_linux.go
@@ -38,6 +38,7 @@ import (
 type linuxDataplane struct {
 	allowIPForwarding bool
 	mtu               int
+	queues            int
 	logger            *logrus.Entry
 }
 
@@ -45,6 +46,7 @@ func NewLinuxDataplane(conf types.NetConf, logger *logrus.Entry) *linuxDataplane
 	return &linuxDataplane{
 		allowIPForwarding: conf.ContainerSettings.AllowIPForwarding,
 		mtu:               conf.MTU,
+		queues:            conf.NumQueues,
 		logger:            logger,
 	}
 }
@@ -76,8 +78,10 @@ func (d *linuxDataplane) DoNetworking(
 	err = ns.WithNetNSPath(args.Netns, func(hostNS ns.NetNS) error {
 		veth := &netlink.Veth{
 			LinkAttrs: netlink.LinkAttrs{
-				Name: contVethName,
-				MTU:  d.mtu,
+				Name:        contVethName,
+				MTU:         d.mtu,
+				NumTxQueues: d.queues,
+				NumRxQueues: d.queues,
 			},
 			PeerName: hostVethName,
 		}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -152,6 +152,9 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		logrus.WithField("mtu", mtu).Debug("Using MTU from /var/lib/calico/mtu")
 		conf.MTU = mtu
 	}
+	if conf.NumQueues <= 0 {
+		conf.NumQueues = 1
+	}
 
 	// Determine which node name to use.
 	nodename := utils.DetermineNodename(conf)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -80,7 +80,7 @@ type NetConf struct {
 	} `json:"ipam,omitempty"`
 	Args                 Args                   `json:"args"`
 	MTU                  int                    `json:"mtu"`
-	NumQueues            int                    `json:"n_queues"`
+	NumQueues            int                    `json:"num_queues"`
 	Nodename             string                 `json:"nodename"`
 	NodenameFile         string                 `json:"nodename_file"`
 	IPAMLockFile         string                 `json:"ipam_lock_file"`

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -80,6 +80,7 @@ type NetConf struct {
 	} `json:"ipam,omitempty"`
 	Args                 Args                   `json:"args"`
 	MTU                  int                    `json:"mtu"`
+	NumQueues            int                    `json:"n_queues"`
 	Nodename             string                 `json:"nodename"`
 	NodenameFile         string                 `json:"nodename_file"`
 	IPAMLockFile         string                 `json:"ipam_lock_file"`

--- a/tests/calico_cni_k8s_test.go
+++ b/tests/calico_cni_k8s_test.go
@@ -314,6 +314,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				Protocol:  syscall.RTPROT_BOOT,
 				Table:     syscall.RT_TABLE_MAIN,
 				Type:      syscall.RTN_UNICAST,
+				Family:    syscall.AF_INET,
 			}))
 
 			// Routes and interface in netns
@@ -328,6 +329,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 					Protocol:  syscall.RTPROT_BOOT,
 					Table:     syscall.RT_TABLE_MAIN,
 					Type:      syscall.RTN_UNICAST,
+					Family:    syscall.AF_INET,
 				}),
 				ContainElement(netlink.Route{
 					LinkIndex: contVeth.Attrs().Index,
@@ -336,6 +338,7 @@ var _ = Describe("Kubernetes CNI tests", func() {
 					Protocol:  syscall.RTPROT_BOOT,
 					Table:     syscall.RT_TABLE_MAIN,
 					Type:      syscall.RTN_UNICAST,
+					Family:    syscall.AF_INET,
 				})))
 
 			// Delete container

--- a/tests/calico_cni_test.go
+++ b/tests/calico_cni_test.go
@@ -167,6 +167,7 @@ var _ = Describe("CalicoCni", func() {
 				Protocol:  syscall.RTPROT_BOOT,
 				Table:     syscall.RT_TABLE_MAIN,
 				Type:      syscall.RTN_UNICAST,
+				Family:    syscall.AF_INET,
 			}))
 
 			// Routes and interface in netns
@@ -180,6 +181,7 @@ var _ = Describe("CalicoCni", func() {
 				Protocol:  syscall.RTPROT_BOOT,
 				Table:     syscall.RT_TABLE_MAIN,
 				Type:      syscall.RTN_UNICAST,
+				Family:    syscall.AF_INET,
 			}),
 				ContainElement(netlink.Route{
 					LinkIndex: contVeth.Attrs().Index,
@@ -188,6 +190,7 @@ var _ = Describe("CalicoCni", func() {
 					Protocol:  syscall.RTPROT_BOOT,
 					Table:     syscall.RT_TABLE_MAIN,
 					Type:      syscall.RTN_UNICAST,
+					Family:    syscall.AF_INET,
 				})))
 
 			_, err = testutils.DeleteContainerWithId(netconf, contNs.Path(), "", testutils.TEST_DEFAULT_NS, containerID)


### PR DESCRIPTION
Signed-off-by: chenqijun <chenqijun@corp.netease.com>

## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Now we use vpp + vcl to accelerate apps in containers, using xdp/afxdp to redirect packet from veth to vpp. 
vpp has more than one workers to process packet in our situation,  
only one vpp worker works when veth has one queue, it affect some performance.

It depend more recent kernel support.


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
