### PR TITLE
fix cluster.server placeholder in writeKubeconfig

### DIFF
--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -429,7 +429,7 @@ kind: Config
 clusters:
 - name: local
   cluster:
-    server: __KUBERNETES_SERVICE_PROTOCOL__://[__KUBERNETES_SERVICE_HOST__]:__KUBERNETES_SERVICE_PORT__
+    server: __KUBERNETES_SERVICE_PROTOCOL__://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__
     __TLS_CFG__
 users:
 - name: calico


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->

fix cluster.server placeholder in writeKubeconfig, remove unnessary square brackets or the server may like 'https://[169.254.0.1]:443'


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
