### PR TITLE
Configure sysctls and suid bits so calico-node can be run as non-privileged

### DIFF
--- a/pkg/dataplane/linux/dataplane_linux.go
+++ b/pkg/dataplane/linux/dataplane_linux.go
@@ -382,6 +382,13 @@ func (d *linuxDataplane) configureSysctls(hostVethName string, hasIPv4, hasIPv6 
 	var err error
 
 	if hasIPv4 {
+		// Enable routing to localhost.  This is required to allow for NAT to the local
+		// host.
+		err := writeProcSys(fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/route_localnet", hostVethName), "1")
+		if err != nil {
+			return fmt.Errorf("failed to set net.ipv4.conf.%s.route_localnet=1: %s", hostVethName, err)
+		}
+
 		// Normally, the kernel has a delay before responding to proxy ARP but we know
 		// that's not needed in a Calico network so we disable it.
 		if err = writeProcSys(fmt.Sprintf("/proc/sys/net/ipv4/neigh/%s/proxy_delay", hostVethName), "0"); err != nil {

--- a/tests/calico_cni_k8s_test.go
+++ b/tests/calico_cni_k8s_test.go
@@ -302,6 +302,10 @@ var _ = Describe("Kubernetes CNI tests", func() {
 			err = testutils.CheckSysctlValue(fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/forwarding", interfaceName), "1")
 			Expect(err).ShouldNot(HaveOccurred())
 
+			// Assert sysctl values are set for what we would expect for an endpoint.
+			err = checkInterfaceConfig(interfaceName, "4")
+			Expect(err).ShouldNot(HaveOccurred())
+
 			// Assert if the host side route is programmed correctly.
 			hostRoutes, err := netlink.RouteList(hostVeth, syscall.AF_INET)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -456,6 +460,10 @@ var _ = Describe("Kubernetes CNI tests", func() {
 						Port:     555,
 					}},
 				}))
+
+				// Assert sysctl values are set for what we would expect for an endpoint.
+				err = checkInterfaceConfig(interfaceName, "4")
+				Expect(err).ShouldNot(HaveOccurred())
 
 				// Delete container
 				_, err = testutils.DeleteContainer(netconf, contNs.Path(), name, testutils.K8S_TEST_NS)
@@ -1671,6 +1679,10 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				Orchestrator:       api.OrchestratorKubernetes,
 			}))
 
+			// Assert sysctl values are set for what we would expect for an endpoint.
+			err = checkInterfaceConfig(interfaceName, "4")
+			Expect(err).ShouldNot(HaveOccurred())
+
 			// Delete the container.
 			_, err = testutils.DeleteContainer(netconf, contNs.Path(), name, testutils.K8S_TEST_NS)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -1871,6 +1883,10 @@ var _ = Describe("Kubernetes CNI tests", func() {
 
 			// Check the pod's IP annotations.
 			checkPodIPAnnotations(clientset, testutils.K8S_TEST_NS, name, "20.0.0.111/32", "20.0.0.111/32")
+
+			// Assert sysctl values are set for what we would expect for an endpoint.
+			err = checkInterfaceConfig(interfaceName, "4")
+			Expect(err).ShouldNot(HaveOccurred())
 
 			// Delete the container.
 			_, err = testutils.DeleteContainer(netconfCalicoIPAM, netNS.Path(), name, testutils.K8S_TEST_NS)
@@ -2786,6 +2802,10 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				}},
 			}))
 
+			// Assert sysctl values are set for what we would expect for an endpoint.
+			err = checkInterfaceConfig(interfaceName, "4")
+			Expect(err).ShouldNot(HaveOccurred())
+
 			_, err = testutils.DeleteContainer(netconf, contNs.Path(), name, testutils.K8S_TEST_NS)
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -2939,6 +2959,10 @@ var _ = Describe("Kubernetes CNI tests", func() {
 				}},
 			}))
 
+			// Assert sysctl values are set for what we would expect for an endpoint.
+			err = checkInterfaceConfig(interfaceName, "4")
+			Expect(err).ShouldNot(HaveOccurred())
+
 			_, err = testutils.DeleteContainer(netconf, contNs.Path(), name, testutils.K8S_TEST_NS)
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -3026,4 +3050,46 @@ func checkPodIPAnnotations(clientset *kubernetes.Clientset, ns, name, expectedIP
 		Expect(pod.Annotations["cni.projectcalico.org/podIP"]).To(Equal(expectedIP))
 		Expect(pod.Annotations["cni.projectcalico.org/podIPs"]).To(Equal(expectedIPs))
 	}
+}
+
+func checkInterfaceConfig(name, ipVersion string) error {
+	err := testutils.CheckSysctlValue(fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/accept_ra", name), "0")
+	if err != nil {
+		return err
+	}
+
+	if ipVersion == "4" {
+		err = testutils.CheckSysctlValue(fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/route_localnet", name), "1")
+		if err != nil {
+			return err
+		}
+
+		err = testutils.CheckSysctlValue(fmt.Sprintf("/proc/sys/net/ipv4/neigh/%s/proxy_delay", name), "0")
+		if err != nil {
+			return err
+		}
+
+		err = testutils.CheckSysctlValue(fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/proxy_arp", name), "1")
+		if err != nil {
+			return err
+		}
+
+		err = testutils.CheckSysctlValue(fmt.Sprintf("/proc/sys/net/ipv4/conf/%s/forwarding", name), "1")
+		if err != nil {
+			return err
+		}
+	} else if ipVersion == "6" {
+		err = testutils.CheckSysctlValue(fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/proxy_ndp", name), "1")
+		if err != nil {
+			return err
+		}
+
+		err = testutils.CheckSysctlValue(fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/forwarding", name), "1")
+		if err != nil {
+			return err
+		}
+
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits.
Please include
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
- links to issues that this PR addresses
-->
Syncs up the sysctl configuration from [felix](https://github.com/projectcalico/felix/blob/b4e393f2faa942f7f1722ebf18871abcb0d58b73/dataplane/linux/endpoint_mgr.go#L1160) so that calico-node can be run as non-privileged. Also sets the SUID bit on the appropriate calico binaries so that they may also be run as non-root.


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
